### PR TITLE
Show multiple providers in the menu bar

### DIFF
--- a/AIUsage/MenuBar/MenuBarController.swift
+++ b/AIUsage/MenuBar/MenuBarController.swift
@@ -21,6 +21,113 @@ struct PanelToggleGate {
 }
 
 @MainActor
+enum MenuBarStatusImageRenderer {
+    private static let iconSize: CGFloat = 15
+    private static let iconTextSpacing: CGFloat = 4
+    private static let itemSpacing: CGFloat = 8
+
+    static func image(
+        for readings: [MenuBarReading],
+        font: NSFont
+    ) -> NSImage {
+        let entries = readings.map { reading in
+            (
+                reading: reading,
+                presentation: MenuBarPresentation(reading: reading)
+            )
+        }
+        let textAttributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: NSColor.black
+        ]
+        let metrics = entries.map { entry in
+            let text = titleText(for: entry.presentation)
+            let textSize = (text as NSString).size(withAttributes: textAttributes)
+            let width = iconSize + (
+                text.isEmpty ? 0 : iconTextSpacing + ceil(textSize.width)
+            )
+            return (text: text, textSize: textSize, width: width)
+        }
+        let width = metrics.map(\.width).reduce(0, +) +
+            itemSpacing * CGFloat(max(entries.count - 1, 0))
+        let height = max(
+            iconSize,
+            ceil(font.ascender - font.descender + font.leading)
+        )
+
+        let image = NSImage(
+            size: NSSize(width: ceil(width), height: ceil(height)),
+            flipped: false
+        ) { destination in
+            var x = destination.minX
+
+            for (index, entry) in entries.enumerated() {
+                let metric = metrics[index]
+                let icon = icon(for: entry.reading.provider)
+                icon.draw(
+                    in: NSRect(
+                        x: x,
+                        y: destination.midY - iconSize / 2,
+                        width: iconSize,
+                        height: iconSize
+                    ),
+                    from: .zero,
+                    operation: .sourceOver,
+                    fraction: 1
+                )
+                x += iconSize
+
+                if !metric.text.isEmpty {
+                    x += iconTextSpacing
+                    (metric.text as NSString).draw(
+                        at: NSPoint(
+                            x: x,
+                            y: destination.midY - metric.textSize.height / 2
+                        ),
+                        withAttributes: textAttributes
+                    )
+                    x += ceil(metric.textSize.width)
+                }
+
+                if index < entries.count - 1 {
+                    x += itemSpacing
+                }
+            }
+
+            return true
+        }
+        image.isTemplate = true
+        return image
+    }
+
+    private static func titleText(
+        for presentation: MenuBarPresentation
+    ) -> String {
+        var title = presentation.valueText ?? ""
+        if presentation.showsStaleIndicator {
+            title = title.isEmpty ? "⚠︎" : "\(title) ⚠︎"
+        }
+        return title
+    }
+
+    private static func icon(for provider: ProviderID?) -> NSImage {
+        if let provider {
+            return ProviderIcon.templateImage(for: provider, size: iconSize)
+        }
+
+        guard let source = NSImage(
+            systemSymbolName: "gauge.with.dots.needle.50percent",
+            accessibilityDescription: nil
+        ), let image = source.copy() as? NSImage else {
+            return NSImage(size: NSSize(width: iconSize, height: iconSize))
+        }
+        image.size = NSSize(width: iconSize, height: iconSize)
+        image.isTemplate = true
+        return image
+    }
+}
+
+@MainActor
 final class MenuBarController: NSObject, NSPopoverDelegate {
     private static let panelWidth: CGFloat = 392
 
@@ -157,7 +264,7 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
 
         let state = withObservationTracking {
             (
-                reading: store.menuBarReading(
+                readings: store.menuBarReadings(
                     for: preferences.menuBarSelection,
                     window: preferences.menuBarWindow,
                     displayMode: preferences.usageDisplayMode
@@ -171,13 +278,49 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
         }
 
         store.setRefreshInterval(state.refreshInterval)
-        updateStatusItem(with: state.reading)
+        updateStatusItem(with: state.readings)
     }
 
-    private func updateStatusItem(with reading: MenuBarReading) {
+    private func updateStatusItem(with readings: [MenuBarReading]) {
         guard let button = statusItem?.button else { return }
 
-        let presentation = MenuBarPresentation(reading: reading)
+        let collectionPresentation = MenuBarReadingsPresentation(
+            readings: readings
+        )
+        button.toolTip = collectionPresentation.accessibilityLabel
+        button.setAccessibilityLabel(collectionPresentation.accessibilityLabel)
+
+        guard readings.count != 1 else {
+            updateStatusItem(
+                button,
+                with: readings[0],
+                presentation: collectionPresentation.items[0]
+            )
+            return
+        }
+
+        guard !readings.isEmpty else {
+            button.attributedTitle = NSAttributedString()
+            button.image = statusImage(for: nil)
+            button.title = ""
+            return
+        }
+
+        button.attributedTitle = NSAttributedString()
+        button.image = nil
+        button.title = ""
+        button.image = MenuBarStatusImageRenderer.image(
+            for: readings,
+            font: button.font ?? NSFont.menuBarFont(ofSize: 0)
+        )
+    }
+
+    private func updateStatusItem(
+        _ button: NSStatusBarButton,
+        with reading: MenuBarReading,
+        presentation: MenuBarPresentation
+    ) {
+        button.attributedTitle = NSAttributedString()
         var title = presentation.valueText ?? ""
         if presentation.showsStaleIndicator {
             title = title.isEmpty ? "⚠︎" : "\(title) ⚠︎"
@@ -185,8 +328,6 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
 
         button.image = statusImage(for: reading.provider)
         button.title = title
-        button.toolTip = presentation.accessibilityLabel
-        button.setAccessibilityLabel(presentation.accessibilityLabel)
     }
 
     private func statusImage(for provider: ProviderID?) -> NSImage {

--- a/AIUsage/Models/ProviderModels.swift
+++ b/AIUsage/Models/ProviderModels.swift
@@ -128,6 +128,7 @@ struct ProviderState: Equatable, Sendable {
 
 enum MenuBarSelection: String, CaseIterable, Identifiable, Sendable {
     case automatic
+    case all
     case claude
     case codex
 
@@ -136,6 +137,7 @@ enum MenuBarSelection: String, CaseIterable, Identifiable, Sendable {
     var title: String {
         switch self {
         case .automatic: "Auto — Highest usage"
+        case .all: "All providers"
         case .claude: "Claude Code"
         case .codex: "Codex"
         }
@@ -143,7 +145,7 @@ enum MenuBarSelection: String, CaseIterable, Identifiable, Sendable {
 
     var provider: ProviderID? {
         switch self {
-        case .automatic: nil
+        case .automatic, .all: nil
         case .claude: .claude
         case .codex: .codex
         }

--- a/AIUsage/Store/UsageStore.swift
+++ b/AIUsage/Store/UsageStore.swift
@@ -151,6 +151,40 @@ final class UsageStore {
         }
     }
 
+    func menuBarReadings(
+        for selection: MenuBarSelection,
+        window windowSelection: MenuBarWindow = .session,
+        displayMode: UsageDisplayMode = .used
+    ) -> [MenuBarReading] {
+        guard selection == .all else {
+            return [
+                menuBarReading(
+                    for: selection,
+                    window: windowSelection,
+                    displayMode: displayMode
+                )
+            ]
+        }
+
+        return ProviderID.allCases.compactMap { provider in
+            guard states[provider]?.isVisibleInDashboard != false else {
+                return nil
+            }
+            let pinnedSelection: MenuBarSelection
+            switch provider {
+            case .claude:
+                pinnedSelection = .claude
+            case .codex:
+                pinnedSelection = .codex
+            }
+            return menuBarReading(
+                for: pinnedSelection,
+                window: windowSelection,
+                displayMode: displayMode
+            )
+        }
+    }
+
     func menuBarReading(
         for selection: MenuBarSelection,
         window windowSelection: MenuBarWindow = .session,
@@ -181,6 +215,19 @@ final class UsageStore {
                 percent: displayMode.displayedPercent(from: highest.1),
                 displayMode: displayMode,
                 isStale: highest.2,
+                showsPlaceholder: false
+            )
+
+        case .all:
+            return menuBarReadings(
+                for: .all,
+                window: windowSelection,
+                displayMode: displayMode
+            ).first ?? MenuBarReading(
+                provider: nil,
+                percent: nil,
+                displayMode: displayMode,
+                isStale: false,
                 showsPlaceholder: false
             )
 

--- a/AIUsage/Views/DashboardView.swift
+++ b/AIUsage/Views/DashboardView.swift
@@ -87,6 +87,8 @@ struct DashboardView: View {
                             } icon: {
                                 if let provider = option.provider {
                                     ProviderIcon(provider: provider, size: 13)
+                                } else if option == .all {
+                                    Image(systemName: "rectangle.3.group")
                                 } else {
                                     Image(systemName: "gauge.with.dots.needle.50percent")
                                 }

--- a/AIUsage/Views/MenuBarLabelView.swift
+++ b/AIUsage/Views/MenuBarLabelView.swift
@@ -28,6 +28,18 @@ struct MenuBarPresentation: Equatable, Sendable {
     }
 }
 
+struct MenuBarReadingsPresentation: Equatable, Sendable {
+    let items: [MenuBarPresentation]
+    let accessibilityLabel: String
+
+    init(readings: [MenuBarReading]) {
+        items = readings.map(MenuBarPresentation.init(reading:))
+        accessibilityLabel = items.isEmpty
+            ? "AI usage"
+            : items.map(\.accessibilityLabel).joined(separator: ", ")
+    }
+}
+
 struct MenuBarLabelView: View {
     let reading: MenuBarReading
 

--- a/AIUsageTests/AppPreferencesTests.swift
+++ b/AIUsageTests/AppPreferencesTests.swift
@@ -32,14 +32,14 @@ final class AppPreferencesTests: XCTestCase {
 
     func testPreferencesPersistUsingExistingKeys() {
         let preferences = AppPreferences(defaults: defaults)
-        preferences.menuBarSelection = .codex
+        preferences.menuBarSelection = .all
         preferences.menuBarWindow = .weekly
         preferences.usageDisplayMode = .used
         preferences.refreshInterval = .thirtyMinutes
 
         let restored = AppPreferences(defaults: defaults)
 
-        XCTAssertEqual(restored.menuBarSelection, .codex)
+        XCTAssertEqual(restored.menuBarSelection, .all)
         XCTAssertEqual(restored.menuBarWindow, .weekly)
         XCTAssertEqual(restored.usageDisplayMode, .used)
         XCTAssertEqual(restored.refreshInterval, .thirtyMinutes)

--- a/AIUsageTests/MenuBarPresentationTests.swift
+++ b/AIUsageTests/MenuBarPresentationTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import XCTest
 @testable import AIUsage
 
@@ -43,5 +44,59 @@ final class MenuBarPresentationTests: XCTestCase {
 
         XCTAssertNil(presentation.valueText)
         XCTAssertEqual(presentation.accessibilityLabel, "AI usage")
+    }
+
+    func testMultipleReadingsKeepProviderValuesAndAccessibilityOrder() {
+        let presentation = MenuBarReadingsPresentation(readings: [
+            MenuBarReading(
+                provider: .claude,
+                percent: 62,
+                displayMode: .used,
+                isStale: false,
+                showsPlaceholder: false
+            ),
+            MenuBarReading(
+                provider: .codex,
+                percent: 28,
+                displayMode: .used,
+                isStale: true,
+                showsPlaceholder: false
+            )
+        ])
+
+        XCTAssertEqual(presentation.items.map(\.valueText), ["62%", "28%"])
+        XCTAssertEqual(
+            presentation.accessibilityLabel,
+            "Claude Code 62 percent used, Codex 28 percent used, stale"
+        )
+    }
+
+    @MainActor
+    func testMultipleReadingStatusImageUsesTemplateRendering() {
+        let readings = [
+            MenuBarReading(
+                provider: .claude,
+                percent: 62,
+                displayMode: .used,
+                isStale: false,
+                showsPlaceholder: false
+            ),
+            MenuBarReading(
+                provider: .codex,
+                percent: 28,
+                displayMode: .used,
+                isStale: false,
+                showsPlaceholder: false
+            )
+        ]
+
+        let image = MenuBarStatusImageRenderer.image(
+            for: readings,
+            font: NSFont.menuBarFont(ofSize: 0)
+        )
+
+        XCTAssertTrue(image.isTemplate)
+        XCTAssertGreaterThan(image.size.width, 50)
+        XCTAssertLessThan(image.size.width, 110)
     }
 }

--- a/AIUsageTests/UsageStoreTests.swift
+++ b/AIUsageTests/UsageStoreTests.swift
@@ -110,6 +110,67 @@ final class UsageStoreTests: XCTestCase {
         )
     }
 
+    func testAllSelectionReturnsEveryAvailableProviderInStableOrder() async {
+        let claude = SequencedProvider(
+            id: .claude,
+            results: [.success(snapshot(provider: .claude, percent: 20))]
+        )
+        let codex = SequencedProvider(
+            id: .codex,
+            results: [.success(snapshot(provider: .codex, percent: 81))]
+        )
+        let store = UsageStore(
+            providers: [claude, codex],
+            availabilityChecker: FixedProviderAvailabilityChecker()
+        )
+
+        await store.refresh()
+
+        XCTAssertEqual(
+            store.menuBarReadings(for: .all),
+            [
+                MenuBarReading(
+                    provider: .claude,
+                    percent: 20,
+                    displayMode: .used,
+                    isStale: false,
+                    showsPlaceholder: false
+                ),
+                MenuBarReading(
+                    provider: .codex,
+                    percent: 81,
+                    displayMode: .used,
+                    isStale: false,
+                    showsPlaceholder: false
+                )
+            ]
+        )
+    }
+
+    func testAllSelectionOmitsUnavailableProviders() async {
+        let claude = SequencedProvider(
+            id: .claude,
+            results: [.success(snapshot(provider: .claude, percent: 20))]
+        )
+        let codex = SequencedProvider(
+            id: .codex,
+            results: [.success(snapshot(provider: .codex, percent: 81))]
+        )
+        let store = UsageStore(
+            providers: [claude, codex],
+            availabilityChecker: FixedProviderAvailabilityChecker(
+                installed: [.claude]
+            )
+        )
+
+        await store.refresh()
+
+        XCTAssertEqual(
+            store.menuBarReadings(for: .all).map(\.provider),
+            [.claude]
+        )
+    }
+
     func testPinnedCodexFallsBackToAvailableWeeklyPeriod() async {
         let weeklyOnly = ProviderSnapshot(
             provider: .codex,


### PR DESCRIPTION
## Summary
- add an All providers menu bar option
- render Claude Code and Codex usage side by side
- hide unavailable providers while preserving single-provider and Auto behavior

## Tests
- xcodebuild test -quiet -project AIUsage.xcodeproj -scheme AIUsage -destination 'platform=macOS'