### PR TITLE
Add configurable provider metrics and credit usage

### DIFF
--- a/AIUsage/AIUsageApp.swift
+++ b/AIUsage/AIUsageApp.swift
@@ -15,31 +15,79 @@ struct AIUsageApp: App {
 
 @MainActor
 final class AIUsageAppDelegate: NSObject, NSApplicationDelegate {
+    let services: AppServices
     private var menuBarController: MenuBarController?
+
+    override init() {
+        services = AppServices(startingUpdater: !Self.isRunningTests)
+        super.init()
+    }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         guard !Self.isRunningTests else { return }
 
-        let preferences = AppPreferences()
-        let store = UsageStore(refreshInterval: preferences.refreshInterval)
-        let launchAtLogin = LaunchAtLoginController()
         if Self.isInstalledInApplicationsFolder {
-            launchAtLogin.enableByDefaultIfNeeded()
+            services.launchAtLogin.enableByDefaultIfNeeded()
         }
 
+        let services = self.services
         let menuBarController = MenuBarController(
-            store: store,
-            preferences: preferences,
-            launchAtLogin: launchAtLogin,
-            updateController: UpdateController()
+            store: services.store,
+            preferences: services.preferences,
+            launchAtLogin: services.launchAtLogin,
+            updateController: services.updateController
         )
         menuBarController.start()
         self.menuBarController = menuBarController
+        installMainMenu()
+
+        Task {
+            await services.store.refresh()
+            services.preferences.configureDefaultMenuBarProviders(
+                availableItemsByProvider:
+                    services.store.availableMenuBarItemsByProvider
+            )
+            if !services.preferences.hasCompletedInitialSetup {
+                menuBarController.showSettings()
+            }
+        }
     }
 
     func applicationWillTerminate(_ notification: Notification) {
         menuBarController?.stop()
         menuBarController = nil
+    }
+
+    @objc
+    private func openSettings(_ sender: Any?) {
+        menuBarController?.showSettings()
+    }
+
+    private func installMainMenu() {
+        let mainMenu = NSMenu()
+        let appMenuItem = NSMenuItem()
+        let appMenu = NSMenu(title: "AI Usage")
+
+        let settingsItem = NSMenuItem(
+            title: "Settings…",
+            action: #selector(openSettings(_:)),
+            keyEquivalent: ","
+        )
+        settingsItem.target = self
+        appMenu.addItem(settingsItem)
+        appMenu.addItem(.separator())
+        let quitItem = NSMenuItem(
+            title: "Quit AI Usage",
+            action: #selector(NSApplication.terminate(_:)),
+            keyEquivalent: "q"
+        )
+        quitItem.target = NSApplication.shared
+        appMenu.addItem(quitItem)
+
+        appMenuItem.submenu = appMenu
+        mainMenu.addItem(appMenuItem)
+
+        NSApplication.shared.mainMenu = mainMenu
     }
 
     private static var isRunningTests: Bool {

--- a/AIUsage/AppServices.swift
+++ b/AIUsage/AppServices.swift
@@ -1,0 +1,18 @@
+@MainActor
+final class AppServices {
+    let preferences: AppPreferences
+    let store: UsageStore
+    let launchAtLogin: LaunchAtLoginController
+    let updateController: UpdateController
+
+    init(startingUpdater: Bool = true) {
+        let preferences = AppPreferences()
+        self.preferences = preferences
+        store = UsageStore(
+            refreshInterval: preferences.refreshInterval,
+            trackedProviderIDs: preferences.trackedProviderIDs
+        )
+        launchAtLogin = LaunchAtLoginController()
+        updateController = UpdateController(startingUpdater: startingUpdater)
+    }
+}

--- a/AIUsage/Infrastructure/ProviderParsing.swift
+++ b/AIUsage/Infrastructure/ProviderParsing.swift
@@ -38,6 +38,10 @@ enum ProviderParsing {
         return nil
     }
 
+    static func centsToDollars(_ cents: Double) -> Double {
+        cents.rounded() / 100
+    }
+
     static func decodeWithHexFallback<T: Decodable>(_ text: String, as type: T.Type) -> T? {
         if let data = text.data(using: .utf8),
            let decoded = try? JSONDecoder().decode(type, from: data) {

--- a/AIUsage/MenuBar/MenuBarController.swift
+++ b/AIUsage/MenuBar/MenuBarController.swift
@@ -23,36 +23,99 @@ struct PanelToggleGate {
 @MainActor
 enum MenuBarStatusImageRenderer {
     private static let iconSize: CGFloat = 15
-    private static let iconTextSpacing: CGFloat = 4
-    private static let itemSpacing: CGFloat = 8
+    private static let iconTextSpacing: CGFloat = 3
+    private static let labelValueSpacing: CGFloat = 1
+    private static let separatorSpacing: CGFloat = 3
+    private static let staleSpacing: CGFloat = 1
+    private static let suffixSpacing: CGFloat = 1
+    private static let microLabelRaise: CGFloat = 2
+    private static let providerSpacing: CGFloat = 9
+
+    private struct TextRun {
+        let text: String
+        let size: NSSize
+
+        var width: CGFloat { ceil(size.width) }
+    }
+
+    private struct MetricRun {
+        let label: TextRun?
+        let value: TextRun
+        let staleIndicator: TextRun?
+        let width: CGFloat
+    }
 
     static func image(
-        for readings: [MenuBarReading],
+        for groups: [MenuBarProviderReadings],
         font: NSFont
     ) -> NSImage {
-        let entries = readings.map { reading in
-            (
-                reading: reading,
-                presentation: MenuBarPresentation(reading: reading)
+        let microFont = NSFont.systemFont(
+            ofSize: max(8, floor(font.pointSize * 0.62)),
+            weight: .semibold
+        )
+        let separator = textRun("·", font: microFont)
+        let entries = groups.map { group in
+            let presentation = MenuBarProviderPresentation(group: group)
+            let metrics = presentation.metrics.map { metric in
+                let label = metric.label.map {
+                    textRun($0, font: microFont)
+                }
+                let value = textRun(metric.valueText, font: font)
+                let staleIndicator = metric.showsStaleIndicator
+                    ? textRun("⚠︎", font: microFont)
+                    : nil
+                return MetricRun(
+                    label: label,
+                    value: value,
+                    staleIndicator: staleIndicator,
+                    width:
+                        (label?.width ?? 0) +
+                        (label == nil ? 0 : labelValueSpacing) +
+                        value.width +
+                        (staleIndicator == nil ? 0 : staleSpacing) +
+                        (staleIndicator?.width ?? 0)
+                )
+            }
+            let separatorsWidth =
+                (separator.width + separatorSpacing * 2) *
+                CGFloat(max(metrics.count - 1, 0))
+            let suffix = presentation.sharedSuffix.map {
+                textRun($0, font: microFont)
+            }
+            let valuesWidth =
+                metrics.map(\.width).reduce(0, +) +
+                separatorsWidth +
+                (suffix == nil ? 0 : suffixSpacing) +
+                (suffix?.width ?? 0)
+            let width = iconSize + (
+                metrics.isEmpty ? 0 : iconTextSpacing + ceil(valuesWidth)
+            )
+            return (
+                provider: group.provider,
+                metrics: metrics,
+                suffix: suffix,
+                width: width
             )
         }
-        let textAttributes: [NSAttributedString.Key: Any] = [
+        let valueAttributes: [NSAttributedString.Key: Any] = [
             .font: font,
             .foregroundColor: NSColor.black
         ]
-        let metrics = entries.map { entry in
-            let text = titleText(for: entry.presentation)
-            let textSize = (text as NSString).size(withAttributes: textAttributes)
-            let width = iconSize + (
-                text.isEmpty ? 0 : iconTextSpacing + ceil(textSize.width)
-            )
-            return (text: text, textSize: textSize, width: width)
-        }
-        let width = metrics.map(\.width).reduce(0, +) +
-            itemSpacing * CGFloat(max(entries.count - 1, 0))
+        let microAttributes: [NSAttributedString.Key: Any] = [
+            .font: microFont,
+            .foregroundColor: NSColor.black
+        ]
+        let width = entries.map(\.width).reduce(0, +) +
+            providerSpacing * CGFloat(max(entries.count - 1, 0))
         let height = max(
             iconSize,
-            ceil(font.ascender - font.descender + font.leading)
+            ceil(font.ascender - font.descender + font.leading),
+            ceil(
+                microFont.ascender -
+                    microFont.descender +
+                    microFont.leading +
+                    microLabelRaise
+            )
         )
 
         let image = NSImage(
@@ -62,8 +125,7 @@ enum MenuBarStatusImageRenderer {
             var x = destination.minX
 
             for (index, entry) in entries.enumerated() {
-                let metric = metrics[index]
-                let icon = icon(for: entry.reading.provider)
+                let icon = icon(for: entry.provider)
                 icon.draw(
                     in: NSRect(
                         x: x,
@@ -77,20 +139,76 @@ enum MenuBarStatusImageRenderer {
                 )
                 x += iconSize
 
-                if !metric.text.isEmpty {
+                if !entry.metrics.isEmpty {
                     x += iconTextSpacing
-                    (metric.text as NSString).draw(
+                }
+                for (metricIndex, metric) in entry.metrics.enumerated() {
+                    if metricIndex > 0 {
+                        x += separatorSpacing
+                        (separator.text as NSString).draw(
+                            at: NSPoint(
+                                x: x,
+                                y: destination.midY -
+                                    separator.size.height / 2
+                            ),
+                            withAttributes: microAttributes
+                        )
+                        x += separator.width + separatorSpacing
+                    }
+
+                    if let label = metric.label {
+                        (label.text as NSString).draw(
+                            at: NSPoint(
+                                x: x,
+                                y: destination.midY -
+                                    label.size.height / 2 +
+                                    microLabelRaise
+                            ),
+                            withAttributes: microAttributes
+                        )
+                        x += label.width + labelValueSpacing
+                    }
+
+                    (metric.value.text as NSString).draw(
                         at: NSPoint(
                             x: x,
-                            y: destination.midY - metric.textSize.height / 2
+                            y: destination.midY -
+                                metric.value.size.height / 2
                         ),
-                        withAttributes: textAttributes
+                        withAttributes: valueAttributes
                     )
-                    x += ceil(metric.textSize.width)
+                    x += metric.value.width
+
+                    if metricIndex == entry.metrics.count - 1,
+                       let suffix = entry.suffix {
+                        x += suffixSpacing
+                        (suffix.text as NSString).draw(
+                            at: NSPoint(
+                                x: x,
+                                y: destination.midY -
+                                    suffix.size.height / 2
+                            ),
+                            withAttributes: microAttributes
+                        )
+                        x += suffix.width
+                    }
+
+                    if let staleIndicator = metric.staleIndicator {
+                        x += staleSpacing
+                        (staleIndicator.text as NSString).draw(
+                            at: NSPoint(
+                                x: x,
+                                y: destination.midY -
+                                    staleIndicator.size.height / 2
+                            ),
+                            withAttributes: microAttributes
+                        )
+                        x += staleIndicator.width
+                    }
                 }
 
                 if index < entries.count - 1 {
-                    x += itemSpacing
+                    x += providerSpacing
                 }
             }
 
@@ -100,37 +218,36 @@ enum MenuBarStatusImageRenderer {
         return image
     }
 
-    private static func titleText(
-        for presentation: MenuBarPresentation
-    ) -> String {
-        var title = presentation.valueText ?? ""
-        if presentation.showsStaleIndicator {
-            title = title.isEmpty ? "⚠︎" : "\(title) ⚠︎"
-        }
-        return title
+    private static func textRun(_ text: String, font: NSFont) -> TextRun {
+        TextRun(
+            text: text,
+            size: (text as NSString).size(withAttributes: [
+                .font: font
+            ])
+        )
     }
 
-    private static func icon(for provider: ProviderID?) -> NSImage {
-        if let provider {
-            return ProviderIcon.templateImage(for: provider, size: iconSize)
-        }
+    private static func icon(for provider: ProviderID) -> NSImage {
+        ProviderIcon.templateImage(for: provider, size: iconSize)
+    }
+}
 
-        guard let source = NSImage(
-            systemSymbolName: "gauge.with.dots.needle.50percent",
-            accessibilityDescription: nil
-        ), let image = source.copy() as? NSImage else {
-            return NSImage(size: NSSize(width: iconSize, height: iconSize))
+enum MenuBarPanelRoute: Equatable {
+    case dashboard
+    case settings
+
+    var width: CGFloat {
+        switch self {
+        case .dashboard:
+            392
+        case .settings:
+            560
         }
-        image.size = NSSize(width: iconSize, height: iconSize)
-        image.isTemplate = true
-        return image
     }
 }
 
 @MainActor
 final class MenuBarController: NSObject, NSPopoverDelegate {
-    private static let panelWidth: CGFloat = 392
-
     private let store: UsageStore
     private let preferences: AppPreferences
     private let launchAtLogin: LaunchAtLoginController
@@ -139,6 +256,7 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
 
     private var statusItem: NSStatusItem?
     private var popover: NSPopover?
+    private var panelRoute: MenuBarPanelRoute = .dashboard
     private var isStarted = false
     private var toggleGate = PanelToggleGate()
 
@@ -198,47 +316,92 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
         if popover?.isShown == true {
             popover?.performClose(sender)
         } else {
-            showPanel()
+            showPanel(route: .dashboard)
         }
     }
 
-    private func showPanel() {
+    func showSettings() {
+        guard isStarted else { return }
+        preferences.markInitialSetupCompleted()
+        showPanel(route: .settings)
+    }
+
+    private func showDashboard() {
+        showPanel(route: .dashboard)
+    }
+
+    private func showPanel(route: MenuBarPanelRoute) {
         guard let button = statusItem?.button else { return }
 
-        let rootView = DashboardRootView(
-            store: store,
-            launchAtLogin: launchAtLogin,
-            preferences: preferences,
-            updateController: updateController
-        )
-        let hostingController = NSHostingController(rootView: rootView)
-        hostingController.sizingOptions = [.preferredContentSize]
-
-        let measuredSize = hostingController.sizeThatFits(
-            in: NSSize(
-                width: Self.panelWidth,
-                height: .greatestFiniteMagnitude
-            )
-        )
-        let contentSize = NSSize(
-            width: Self.panelWidth,
-            height: ceil(measuredSize.height)
-        )
-        hostingController.preferredContentSize = contentSize
+        if let popover, popover.isShown {
+            guard panelRoute != route else { return }
+            installContent(for: route, in: popover)
+            return
+        }
 
         let popover = NSPopover()
         popover.behavior = .transient
         popover.animates = true
         popover.delegate = self
-        popover.contentSize = contentSize
-        popover.contentViewController = hostingController
         self.popover = popover
 
+        installContent(for: route, in: popover)
         popover.show(
             relativeTo: button.bounds,
             of: button,
             preferredEdge: .minY
         )
+    }
+
+    private func installContent(
+        for route: MenuBarPanelRoute,
+        in popover: NSPopover
+    ) {
+        let rootView: AnyView
+        switch route {
+        case .dashboard:
+            rootView = AnyView(
+                DashboardRootView(
+                    store: store,
+                    launchAtLogin: launchAtLogin,
+                    preferences: preferences,
+                    updateController: updateController,
+                    openSettings: { [weak self] in
+                        self?.showSettings()
+                    }
+                )
+            )
+        case .settings:
+            rootView = AnyView(
+                SettingsRootView(
+                    store: store,
+                    preferences: preferences,
+                    launchAtLogin: launchAtLogin,
+                    updateController: updateController,
+                    showDashboard: { [weak self] in
+                        self?.showDashboard()
+                    }
+                )
+            )
+        }
+
+        let hostingController = NSHostingController(rootView: rootView)
+        hostingController.sizingOptions = [.preferredContentSize]
+
+        let measuredSize = hostingController.sizeThatFits(
+            in: NSSize(
+                width: route.width,
+                height: .greatestFiniteMagnitude
+            )
+        )
+        let contentSize = NSSize(
+            width: route.width,
+            height: ceil(measuredSize.height)
+        )
+        hostingController.preferredContentSize = contentSize
+        popover.contentViewController = hostingController
+        popover.contentSize = contentSize
+        panelRoute = route
     }
 
     func popoverDidClose(_ notification: Notification) {
@@ -257,18 +420,20 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
         popover?.delegate = nil
         popover?.contentViewController = nil
         popover = nil
+        panelRoute = .dashboard
     }
 
     private func trackMenuBarState() {
         guard isStarted else { return }
 
+        store.setTrackedProviders(preferences.trackedProviderIDs)
         let state = withObservationTracking {
             (
-                readings: store.menuBarReadings(
-                    for: preferences.menuBarSelection,
-                    window: preferences.menuBarWindow,
+                groups: store.menuBarProviderReadings(
+                    for: preferences.menuBarProviderConfigurations,
                     displayMode: preferences.usageDisplayMode
                 ),
+                trackedProviders: preferences.trackedProviderIDs,
                 refreshInterval: preferences.refreshInterval
             )
         } onChange: { [weak self] in
@@ -277,29 +442,21 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
             }
         }
 
+        store.setTrackedProviders(state.trackedProviders)
         store.setRefreshInterval(state.refreshInterval)
-        updateStatusItem(with: state.readings)
+        updateStatusItem(with: state.groups)
     }
 
-    private func updateStatusItem(with readings: [MenuBarReading]) {
+    private func updateStatusItem(with groups: [MenuBarProviderReadings]) {
         guard let button = statusItem?.button else { return }
 
         let collectionPresentation = MenuBarReadingsPresentation(
-            readings: readings
+            groups: groups
         )
         button.toolTip = collectionPresentation.accessibilityLabel
         button.setAccessibilityLabel(collectionPresentation.accessibilityLabel)
 
-        guard readings.count != 1 else {
-            updateStatusItem(
-                button,
-                with: readings[0],
-                presentation: collectionPresentation.items[0]
-            )
-            return
-        }
-
-        guard !readings.isEmpty else {
+        guard !groups.isEmpty else {
             button.attributedTitle = NSAttributedString()
             button.image = statusImage(for: nil)
             button.title = ""
@@ -310,24 +467,9 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
         button.image = nil
         button.title = ""
         button.image = MenuBarStatusImageRenderer.image(
-            for: readings,
+            for: groups,
             font: button.font ?? NSFont.menuBarFont(ofSize: 0)
         )
-    }
-
-    private func updateStatusItem(
-        _ button: NSStatusBarButton,
-        with reading: MenuBarReading,
-        presentation: MenuBarPresentation
-    ) {
-        button.attributedTitle = NSAttributedString()
-        var title = presentation.valueText ?? ""
-        if presentation.showsStaleIndicator {
-            title = title.isEmpty ? "⚠︎" : "\(title) ⚠︎"
-        }
-
-        button.image = statusImage(for: reading.provider)
-        button.title = title
     }
 
     private func statusImage(for provider: ProviderID?) -> NSImage {
@@ -352,18 +494,36 @@ private struct DashboardRootView: View {
     let launchAtLogin: LaunchAtLoginController
     @Bindable var preferences: AppPreferences
     @Bindable var updateController: UpdateController
+    let openSettings: @MainActor () -> Void
 
     var body: some View {
         DashboardView(
             store: store,
             launchAtLogin: launchAtLogin,
-            menuBarSelection: $preferences.menuBarSelection,
-            menuBarWindow: $preferences.menuBarWindow,
             usageDisplayMode: $preferences.usageDisplayMode,
             refreshInterval: $preferences.refreshInterval,
             availableUpdateVersion: updateController.availableVersion,
             isCheckingForUpdates: updateController.isChecking,
-            checkForUpdates: updateController.checkForUpdates
+            checkForUpdates: updateController.checkForUpdates,
+            openSettings: openSettings
+        )
+    }
+}
+
+private struct SettingsRootView: View {
+    let store: UsageStore
+    @Bindable var preferences: AppPreferences
+    @Bindable var launchAtLogin: LaunchAtLoginController
+    @Bindable var updateController: UpdateController
+    let showDashboard: @MainActor () -> Void
+
+    var body: some View {
+        SettingsView(
+            store: store,
+            preferences: preferences,
+            launchAtLogin: launchAtLogin,
+            updateController: updateController,
+            showDashboard: showDashboard
         )
     }
 }

--- a/AIUsage/MenuBar/MenuBarController.swift
+++ b/AIUsage/MenuBar/MenuBarController.swift
@@ -21,6 +21,113 @@ struct PanelToggleGate {
 }
 
 @MainActor
+enum MenuBarStatusImageRenderer {
+    private static let iconSize: CGFloat = 15
+    private static let iconTextSpacing: CGFloat = 4
+    private static let itemSpacing: CGFloat = 8
+
+    static func image(
+        for readings: [MenuBarReading],
+        font: NSFont
+    ) -> NSImage {
+        let entries = readings.map { reading in
+            (
+                reading: reading,
+                presentation: MenuBarPresentation(reading: reading)
+            )
+        }
+        let textAttributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: NSColor.black
+        ]
+        let metrics = entries.map { entry in
+            let text = titleText(for: entry.presentation)
+            let textSize = (text as NSString).size(withAttributes: textAttributes)
+            let width = iconSize + (
+                text.isEmpty ? 0 : iconTextSpacing + ceil(textSize.width)
+            )
+            return (text: text, textSize: textSize, width: width)
+        }
+        let width = metrics.map(\.width).reduce(0, +) +
+            itemSpacing * CGFloat(max(entries.count - 1, 0))
+        let height = max(
+            iconSize,
+            ceil(font.ascender - font.descender + font.leading)
+        )
+
+        let image = NSImage(
+            size: NSSize(width: ceil(width), height: ceil(height)),
+            flipped: false
+        ) { destination in
+            var x = destination.minX
+
+            for (index, entry) in entries.enumerated() {
+                let metric = metrics[index]
+                let icon = icon(for: entry.reading.provider)
+                icon.draw(
+                    in: NSRect(
+                        x: x,
+                        y: destination.midY - iconSize / 2,
+                        width: iconSize,
+                        height: iconSize
+                    ),
+                    from: .zero,
+                    operation: .sourceOver,
+                    fraction: 1
+                )
+                x += iconSize
+
+                if !metric.text.isEmpty {
+                    x += iconTextSpacing
+                    (metric.text as NSString).draw(
+                        at: NSPoint(
+                            x: x,
+                            y: destination.midY - metric.textSize.height / 2
+                        ),
+                        withAttributes: textAttributes
+                    )
+                    x += ceil(metric.textSize.width)
+                }
+
+                if index < entries.count - 1 {
+                    x += itemSpacing
+                }
+            }
+
+            return true
+        }
+        image.isTemplate = true
+        return image
+    }
+
+    private static func titleText(
+        for presentation: MenuBarPresentation
+    ) -> String {
+        var title = presentation.valueText ?? ""
+        if presentation.showsStaleIndicator {
+            title = title.isEmpty ? "⚠︎" : "\(title) ⚠︎"
+        }
+        return title
+    }
+
+    private static func icon(for provider: ProviderID?) -> NSImage {
+        if let provider {
+            return ProviderIcon.templateImage(for: provider, size: iconSize)
+        }
+
+        guard let source = NSImage(
+            systemSymbolName: "gauge.with.dots.needle.50percent",
+            accessibilityDescription: nil
+        ), let image = source.copy() as? NSImage else {
+            return NSImage(size: NSSize(width: iconSize, height: iconSize))
+        }
+        image.size = NSSize(width: iconSize, height: iconSize)
+        image.isTemplate = true
+        return image
+    }
+}
+
+@MainActor
 final class MenuBarController: NSObject, NSPopoverDelegate {
     private static let panelWidth: CGFloat = 392
 
@@ -157,7 +264,7 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
 
         let state = withObservationTracking {
             (
-                reading: store.menuBarReading(
+                readings: store.menuBarReadings(
                     for: preferences.menuBarSelection,
                     window: preferences.menuBarWindow,
                     displayMode: preferences.usageDisplayMode
@@ -171,13 +278,49 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
         }
 
         store.setRefreshInterval(state.refreshInterval)
-        updateStatusItem(with: state.reading)
+        updateStatusItem(with: state.readings)
     }
 
-    private func updateStatusItem(with reading: MenuBarReading) {
+    private func updateStatusItem(with readings: [MenuBarReading]) {
         guard let button = statusItem?.button else { return }
 
-        let presentation = MenuBarPresentation(reading: reading)
+        let collectionPresentation = MenuBarReadingsPresentation(
+            readings: readings
+        )
+        button.toolTip = collectionPresentation.accessibilityLabel
+        button.setAccessibilityLabel(collectionPresentation.accessibilityLabel)
+
+        guard readings.count != 1 else {
+            updateStatusItem(
+                button,
+                with: readings[0],
+                presentation: collectionPresentation.items[0]
+            )
+            return
+        }
+
+        guard !readings.isEmpty else {
+            button.attributedTitle = NSAttributedString()
+            button.image = statusImage(for: nil)
+            button.title = ""
+            return
+        }
+
+        button.attributedTitle = NSAttributedString()
+        button.image = nil
+        button.title = ""
+        button.image = MenuBarStatusImageRenderer.image(
+            for: readings,
+            font: button.font ?? NSFont.menuBarFont(ofSize: 0)
+        )
+    }
+
+    private func updateStatusItem(
+        _ button: NSStatusBarButton,
+        with reading: MenuBarReading,
+        presentation: MenuBarPresentation
+    ) {
+        button.attributedTitle = NSAttributedString()
         var title = presentation.valueText ?? ""
         if presentation.showsStaleIndicator {
             title = title.isEmpty ? "⚠︎" : "\(title) ⚠︎"
@@ -185,8 +328,6 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
 
         button.image = statusImage(for: reading.provider)
         button.title = title
-        button.toolTip = presentation.accessibilityLabel
-        button.setAccessibilityLabel(presentation.accessibilityLabel)
     }
 
     private func statusImage(for provider: ProviderID?) -> NSImage {

--- a/AIUsage/Models/ProviderModels.swift
+++ b/AIUsage/Models/ProviderModels.swift
@@ -128,6 +128,7 @@ struct ProviderState: Equatable, Sendable {
 
 enum MenuBarSelection: String, CaseIterable, Identifiable, Sendable {
     case automatic
+    case all
     case claude
     case codex
 
@@ -136,6 +137,7 @@ enum MenuBarSelection: String, CaseIterable, Identifiable, Sendable {
     var title: String {
         switch self {
         case .automatic: "Auto — Highest usage"
+        case .all: "All providers"
         case .claude: "Claude Code"
         case .codex: "Codex"
         }
@@ -143,7 +145,7 @@ enum MenuBarSelection: String, CaseIterable, Identifiable, Sendable {
 
     var provider: ProviderID? {
         switch self {
-        case .automatic: nil
+        case .automatic, .all: nil
         case .claude: .claude
         case .codex: .codex
         }

--- a/AIUsage/Models/ProviderModels.swift
+++ b/AIUsage/Models/ProviderModels.swift
@@ -50,11 +50,58 @@ struct QuotaWindow: Identifiable, Equatable, Sendable {
     var renderedFraction: Double { min(max(usedPercent / 100, 0), 1) }
 }
 
+struct CreditUsage: Equatable, Sendable {
+    let usedAmount: Double?
+    let limitAmount: Double?
+    let balanceAmount: Double?
+    let usedPercent: Double?
+    let currencyCode: String
+    let isUnlimited: Bool
+
+    init(
+        usedAmount: Double? = nil,
+        limitAmount: Double? = nil,
+        balanceAmount: Double? = nil,
+        usedPercent: Double? = nil,
+        currencyCode: String = "USD",
+        isUnlimited: Bool = false
+    ) {
+        self.usedAmount = usedAmount
+        self.limitAmount = limitAmount
+        self.balanceAmount = balanceAmount
+        self.usedPercent = usedPercent
+        self.currencyCode = currencyCode
+        self.isUnlimited = isUnlimited
+    }
+
+    var remainingAmount: Double? {
+        guard let usedAmount, let limitAmount else {
+            return nil
+        }
+        return max(limitAmount - usedAmount, 0)
+    }
+}
+
 struct ProviderSnapshot: Equatable, Sendable {
     let provider: ProviderID
     let planName: String?
     let windows: [QuotaWindow]
+    let creditUsage: CreditUsage?
     let fetchedAt: Date
+
+    init(
+        provider: ProviderID,
+        planName: String?,
+        windows: [QuotaWindow],
+        creditUsage: CreditUsage? = nil,
+        fetchedAt: Date
+    ) {
+        self.provider = provider
+        self.planName = planName
+        self.windows = windows
+        self.creditUsage = creditUsage
+        self.fetchedAt = fetchedAt
+    }
 
     var sessionWindow: QuotaWindow? {
         windows.first { $0.kind == .session }

--- a/AIUsage/Models/ProviderModels.swift
+++ b/AIUsage/Models/ProviderModels.swift
@@ -19,9 +19,18 @@ enum ProviderID: String, CaseIterable, Codable, Identifiable, Sendable {
         case .codex: "ProviderCodex"
         }
     }
+
+    var descriptor: ProviderDescriptor {
+        ProviderDescriptor(
+            id: self,
+            displayName: displayName,
+            iconAssetName: iconAssetName,
+            executableName: rawValue
+        )
+    }
 }
 
-enum QuotaKind: String, Codable, Sendable {
+enum QuotaKind: String, Codable, Hashable, Sendable {
     case session
     case weekly
     case sonnet
@@ -39,6 +48,116 @@ enum QuotaKind: String, Codable, Sendable {
         case .sparkWeekly: "Spark Weekly"
         }
     }
+
+    var menuBarMetric: MenuBarMetricID {
+        switch self {
+        case .session: .session
+        case .weekly: .weekly
+        case .sonnet: .sonnet
+        case .fable: .fable
+        case .sparkSession: .spark
+        case .sparkWeekly: .sparkWeekly
+        }
+    }
+}
+
+enum MenuBarMetricID: String, CaseIterable, Codable, Identifiable, Sendable {
+    case session
+    case weekly
+    case sonnet
+    case fable
+    case spark
+    case sparkWeekly
+    case extraUsage
+    case credits
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .session: "Session"
+        case .weekly: "Weekly"
+        case .sonnet: "Sonnet"
+        case .fable: "Fable"
+        case .spark: "Spark"
+        case .sparkWeekly: "Spark Weekly"
+        case .extraUsage: "Extra Usage"
+        case .credits: "Credits"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .session: "clock"
+        case .weekly: "calendar"
+        case .sonnet: "waveform"
+        case .fable: "book.closed"
+        case .spark: "sparkles"
+        case .sparkWeekly: "calendar.badge.clock"
+        case .extraUsage: "dollarsign.circle"
+        case .credits: "creditcard"
+        }
+    }
+
+    var compactLabel: String {
+        switch self {
+        case .session: "S"
+        case .weekly: "W"
+        case .sonnet: "So"
+        case .fable: "F"
+        case .spark: "Sp"
+        case .sparkWeekly: "SpW"
+        case .extraUsage: "E"
+        case .credits: "C"
+        }
+    }
+
+    var quotaKind: QuotaKind? {
+        switch self {
+        case .session: .session
+        case .weekly: .weekly
+        case .sonnet: .sonnet
+        case .fable: .fable
+        case .spark: .sparkSession
+        case .sparkWeekly: .sparkWeekly
+        case .extraUsage, .credits: nil
+        }
+    }
+}
+
+struct MenuBarItemID: Codable, Hashable, Identifiable, Sendable {
+    let provider: ProviderID
+    let metric: MenuBarMetricID
+
+    var id: String { "\(provider.rawValue).\(metric.rawValue)" }
+    var title: String { "\(provider.displayName) · \(metric.title)" }
+}
+
+struct MenuBarProviderConfiguration:
+    Codable,
+    Equatable,
+    Identifiable,
+    Sendable
+{
+    let provider: ProviderID
+    let metrics: [MenuBarMetricID]
+
+    var id: ProviderID { provider }
+}
+
+struct ProviderDescriptor: Identifiable, Sendable {
+    let id: ProviderID
+    let displayName: String
+    let iconAssetName: String
+    let executableName: String
+}
+
+enum ProviderCatalog {
+    static let all = ProviderID.allCases.map(\.descriptor)
+
+    static func descriptor(for provider: ProviderID) -> ProviderDescriptor {
+        provider.descriptor
+    }
 }
 
 struct QuotaWindow: Identifiable, Equatable, Sendable {
@@ -50,61 +169,109 @@ struct QuotaWindow: Identifiable, Equatable, Sendable {
     var renderedFraction: Double { min(max(usedPercent / 100, 0), 1) }
 }
 
-struct CreditUsage: Equatable, Sendable {
-    let usedAmount: Double?
-    let limitAmount: Double?
-    let balanceAmount: Double?
-    let usedPercent: Double?
-    let currencyCode: String
-    let isUnlimited: Bool
+enum BillingUsage: Equatable, Sendable {
+    case boundedSpend(
+        usedAmount: Double,
+        limitAmount: Double,
+        currencyCode: String
+    )
+    case unboundedSpend(
+        usedAmount: Double,
+        currencyCode: String
+    )
+    case flexCreditBalance(
+        remainingCredits: Int,
+        usdValue: Double
+    )
 
-    init(
-        usedAmount: Double? = nil,
-        limitAmount: Double? = nil,
-        balanceAmount: Double? = nil,
-        usedPercent: Double? = nil,
-        currencyCode: String = "USD",
-        isUnlimited: Bool = false
-    ) {
-        self.usedAmount = usedAmount
-        self.limitAmount = limitAmount
-        self.balanceAmount = balanceAmount
-        self.usedPercent = usedPercent
-        self.currencyCode = currencyCode
-        self.isUnlimited = isUnlimited
-    }
-
-    var remainingAmount: Double? {
-        guard let usedAmount, let limitAmount else {
-            return nil
+    var menuBarMetric: MenuBarMetricID {
+        switch self {
+        case .boundedSpend, .unboundedSpend: .extraUsage
+        case .flexCreditBalance: .credits
         }
-        return max(limitAmount - usedAmount, 0)
     }
+
+    func menuBarValue(
+        displayMode: UsageDisplayMode
+    ) -> MenuBarReadingValue {
+        switch self {
+        case let .boundedSpend(usedAmount, limitAmount, currencyCode):
+            let amount = displayMode == .used
+                ? usedAmount
+                : max(limitAmount - usedAmount, 0)
+            return .money(amount: amount, currencyCode: currencyCode)
+        case let .unboundedSpend(usedAmount, currencyCode):
+            return .money(amount: usedAmount, currencyCode: currencyCode)
+        case let .flexCreditBalance(remainingCredits, usdValue):
+            return .credits(
+                remaining: remainingCredits,
+                usdValue: usdValue
+            )
+        }
+    }
+}
+
+enum MenuBarReadingValue: Equatable, Sendable {
+    case percentage(Double)
+    case money(amount: Double, currencyCode: String)
+    case credits(remaining: Int, usdValue: Double)
 }
 
 struct ProviderSnapshot: Equatable, Sendable {
     let provider: ProviderID
     let planName: String?
     let windows: [QuotaWindow]
-    let creditUsage: CreditUsage?
+    let billingUsage: BillingUsage?
     let fetchedAt: Date
 
     init(
         provider: ProviderID,
         planName: String?,
         windows: [QuotaWindow],
-        creditUsage: CreditUsage? = nil,
+        billingUsage: BillingUsage? = nil,
         fetchedAt: Date
     ) {
         self.provider = provider
         self.planName = planName
         self.windows = windows
-        self.creditUsage = creditUsage
+        self.billingUsage = billingUsage
         self.fetchedAt = fetchedAt
     }
 
     var sessionWindow: QuotaWindow? {
         windows.first { $0.kind == .session }
+    }
+
+    func window(for metric: MenuBarMetricID) -> QuotaWindow? {
+        guard let quotaKind = metric.quotaKind else { return nil }
+        return windows.first { $0.kind == quotaKind }
+    }
+
+    var availableMenuBarItems: [MenuBarItemID] {
+        var items = windows.map {
+            MenuBarItemID(provider: provider, metric: $0.kind.menuBarMetric)
+        }
+        if let billingUsage {
+            items.append(MenuBarItemID(
+                provider: provider,
+                metric: billingUsage.menuBarMetric
+            ))
+        }
+        var seen: Set<MenuBarItemID> = []
+        return items.filter { seen.insert($0).inserted }
+    }
+
+    func menuBarValue(
+        for metric: MenuBarMetricID,
+        displayMode: UsageDisplayMode
+    ) -> MenuBarReadingValue? {
+        if let window = window(for: metric) {
+            return .percentage(
+                displayMode.displayedPercent(from: window.usedPercent)
+            )
+        }
+        guard billingUsage?.menuBarMetric == metric else { return nil }
+        return billingUsage?.menuBarValue(displayMode: displayMode)
     }
 
     func primaryWindow(for selection: MenuBarWindow) -> QuotaWindow? {

--- a/AIUsage/Providers/Claude/ClaudeUsageMapper.swift
+++ b/AIUsage/Providers/Claude/ClaudeUsageMapper.swift
@@ -24,6 +24,7 @@ enum ClaudeUsageMapper {
             provider: .claude,
             planName: planName(credentials),
             windows: windows,
+            creditUsage: creditUsage(body["extra_usage"]),
             fetchedAt: now
         )
     }
@@ -85,5 +86,31 @@ enum ClaudeUsageMapper {
             ))
             return
         }
+    }
+
+    private static func creditUsage(_ value: Any?) -> CreditUsage? {
+        guard let object = ProviderParsing.object(value),
+              object["is_enabled"] as? Bool == true else {
+            return nil
+        }
+
+        let usedAmount = ProviderParsing.double(object["used_credits"])
+            .map { max($0, 0) / 100 }
+        let limitAmount = ProviderParsing.double(object["monthly_limit"])
+            .map { max($0, 0) / 100 }
+        let usedPercent = ProviderParsing.double(object["utilization"])
+            .map { min(max($0, 0), 100) }
+        guard usedAmount != nil || limitAmount != nil || usedPercent != nil else {
+            return nil
+        }
+
+        let currencyCode = ProviderParsing.string(object["currency"])?
+            .uppercased() ?? "USD"
+        return CreditUsage(
+            usedAmount: usedAmount,
+            limitAmount: limitAmount,
+            usedPercent: usedPercent,
+            currencyCode: currencyCode
+        )
     }
 }

--- a/AIUsage/Providers/Claude/ClaudeUsageMapper.swift
+++ b/AIUsage/Providers/Claude/ClaudeUsageMapper.swift
@@ -24,7 +24,7 @@ enum ClaudeUsageMapper {
             provider: .claude,
             planName: planName(credentials),
             windows: windows,
-            creditUsage: creditUsage(body["extra_usage"]),
+            billingUsage: billingUsage(body["extra_usage"]),
             fetchedAt: now
         )
     }
@@ -88,29 +88,31 @@ enum ClaudeUsageMapper {
         }
     }
 
-    private static func creditUsage(_ value: Any?) -> CreditUsage? {
-        guard let object = ProviderParsing.object(value),
-              object["is_enabled"] as? Bool == true else {
+    private static func billingUsage(_ value: Any?) -> BillingUsage? {
+        guard
+            let object = ProviderParsing.object(value),
+            object["is_enabled"] as? Bool == true,
+            let usedCents = ProviderParsing.double(object["used_credits"])
+        else {
             return nil
         }
 
-        let usedAmount = ProviderParsing.double(object["used_credits"])
-            .map { max($0, 0) / 100 }
-        let limitAmount = ProviderParsing.double(object["monthly_limit"])
-            .map { max($0, 0) / 100 }
-        let usedPercent = ProviderParsing.double(object["utilization"])
-            .map { min(max($0, 0), 100) }
-        guard usedAmount != nil || limitAmount != nil || usedPercent != nil else {
+        // Anthropic names these fields "credits", but reports integer US cents.
+        let usedAmount = ProviderParsing.centsToDollars(usedCents)
+        if let limitCents = ProviderParsing.double(object["monthly_limit"]),
+           limitCents > 0 {
+            return .boundedSpend(
+                usedAmount: usedAmount,
+                limitAmount: ProviderParsing.centsToDollars(limitCents),
+                currencyCode: "USD"
+            )
+        }
+        guard usedAmount > 0 else {
             return nil
         }
-
-        let currencyCode = ProviderParsing.string(object["currency"])?
-            .uppercased() ?? "USD"
-        return CreditUsage(
+        return .unboundedSpend(
             usedAmount: usedAmount,
-            limitAmount: limitAmount,
-            usedPercent: usedPercent,
-            currencyCode: currencyCode
+            currencyCode: "USD"
         )
     }
 }

--- a/AIUsage/Providers/Codex/CodexUsageMapper.swift
+++ b/AIUsage/Providers/Codex/CodexUsageMapper.swift
@@ -1,6 +1,9 @@
 import Foundation
 
 enum CodexUsageMapper {
+    // Codex flex credits are worth four US cents each.
+    static let creditUSDRate = 0.04
+
     private enum WindowKind {
         case session
         case weekly
@@ -50,7 +53,7 @@ enum CodexUsageMapper {
             provider: .codex,
             planName: planName(body["plan_type"]),
             windows: windows,
-            creditUsage: creditUsage(body["credits"]),
+            billingUsage: billingUsage(response: response, body: body),
             fetchedAt: now
         )
     }
@@ -176,26 +179,44 @@ enum CodexUsageMapper {
             .contains { $0.contains("spark") }
     }
 
-    private static func creditUsage(_ value: Any?) -> CreditUsage? {
-        guard let object = ProviderParsing.object(value) else {
+    private static func billingUsage(
+        response: HTTPResponse,
+        body: [String: Any]
+    ) -> BillingUsage? {
+        guard let remaining = creditsRemaining(response: response, body: body) else {
             return nil
         }
 
-        let balanceAmount = ProviderParsing.double(object["balance"])
-            .map { max($0, 0) }
-        let isUnlimited = object["unlimited"] as? Bool == true
-        let hasCredits = (object["has_credits"] as? Bool) ??
-            (object["hasCredits"] as? Bool)
-        guard balanceAmount != nil || isUnlimited || hasCredits == true else {
-            return nil
+        // Price the whole-credit balance after flooring, matching Codex/OpenUsage.
+        let floored = remaining.rounded(.down)
+        let remainingCredits: Int
+        if floored <= 0 {
+            remainingCredits = 0
+        } else if floored >= Double(Int.max) {
+            remainingCredits = Int.max
+        } else {
+            remainingCredits = Int(floored)
         }
+        return .flexCreditBalance(
+            remainingCredits: remainingCredits,
+            usdValue: Double(remainingCredits) * creditUSDRate
+        )
+    }
 
-        let currencyCode = ProviderParsing.string(object["currency"])?
-            .uppercased() ?? "USD"
-        return CreditUsage(
-            balanceAmount: balanceAmount,
-            currencyCode: currencyCode,
-            isUnlimited: isUnlimited
+    private static func creditsRemaining(
+        response: HTTPResponse,
+        body: [String: Any]
+    ) -> Double? {
+        if let credits = ProviderParsing.object(body["credits"]) {
+            if let balance = ProviderParsing.double(credits["balance"]) {
+                return balance
+            }
+            if credits["has_credits"] as? Bool == false {
+                return 0
+            }
+        }
+        return ProviderParsing.double(
+            response.header("x-codex-credits-balance")
         )
     }
 }

--- a/AIUsage/Providers/Codex/CodexUsageMapper.swift
+++ b/AIUsage/Providers/Codex/CodexUsageMapper.swift
@@ -50,6 +50,7 @@ enum CodexUsageMapper {
             provider: .codex,
             planName: planName(body["plan_type"]),
             windows: windows,
+            creditUsage: creditUsage(body["credits"]),
             fetchedAt: now
         )
     }
@@ -173,5 +174,28 @@ enum CodexUsageMapper {
             .compactMap(ProviderParsing.string)
             .map { $0.lowercased() }
             .contains { $0.contains("spark") }
+    }
+
+    private static func creditUsage(_ value: Any?) -> CreditUsage? {
+        guard let object = ProviderParsing.object(value) else {
+            return nil
+        }
+
+        let balanceAmount = ProviderParsing.double(object["balance"])
+            .map { max($0, 0) }
+        let isUnlimited = object["unlimited"] as? Bool == true
+        let hasCredits = (object["has_credits"] as? Bool) ??
+            (object["hasCredits"] as? Bool)
+        guard balanceAmount != nil || isUnlimited || hasCredits == true else {
+            return nil
+        }
+
+        let currencyCode = ProviderParsing.string(object["currency"])?
+            .uppercased() ?? "USD"
+        return CreditUsage(
+            balanceAmount: balanceAmount,
+            currencyCode: currencyCode,
+            isUnlimited: isUnlimited
+        )
     }
 }

--- a/AIUsage/Store/AppPreferences.swift
+++ b/AIUsage/Store/AppPreferences.swift
@@ -4,15 +4,53 @@ import Observation
 @MainActor
 @Observable
 final class AppPreferences {
-    var menuBarSelection: MenuBarSelection {
+    private(set) var trackedProviderIDs: Set<ProviderID> {
         didSet {
-            defaults.set(menuBarSelection.rawValue, forKey: Key.menuBarSelection)
+            defaults.set(
+                Self.encode(Array(trackedProviderIDs).sorted {
+                    $0.rawValue < $1.rawValue
+                }),
+                forKey: Key.trackedProviderIDs
+            )
         }
     }
 
-    var menuBarWindow: MenuBarWindow {
+    private(set) var visibleMenuBarProviderIDs: Set<ProviderID> {
         didSet {
-            defaults.set(menuBarWindow.rawValue, forKey: Key.menuBarWindow)
+            defaults.set(
+                Self.encode(Array(visibleMenuBarProviderIDs).sorted {
+                    $0.rawValue < $1.rawValue
+                }),
+                forKey: Key.visibleMenuBarProviderIDs
+            )
+        }
+    }
+
+    private(set) var menuBarMetricSelections:
+        [ProviderID: [MenuBarMetricID]] {
+        didSet {
+            defaults.set(
+                Self.encode(menuBarMetricSelections),
+                forKey: Key.menuBarMetricSelections
+            )
+        }
+    }
+
+    private(set) var hasConfiguredMenuBar: Bool {
+        didSet {
+            defaults.set(
+                hasConfiguredMenuBar,
+                forKey: Key.hasConfiguredMenuBar
+            )
+        }
+    }
+
+    private(set) var hasCompletedInitialSetup: Bool {
+        didSet {
+            defaults.set(
+                hasCompletedInitialSetup,
+                forKey: Key.hasCompletedInitialSetup
+            )
         }
     }
 
@@ -30,19 +68,88 @@ final class AppPreferences {
 
     @ObservationIgnored
     private let defaults: UserDefaults
+    @ObservationIgnored
+    private let pendingMenuBarItems: [MenuBarItemID]?
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
-        menuBarSelection = Self.value(
-            MenuBarSelection.self,
-            forKey: Key.menuBarSelection,
+
+        let restoredProviders = Self.decode(
+            [ProviderID].self,
+            forKey: Key.trackedProviderIDs,
             in: defaults
-        ) ?? .automatic
-        menuBarWindow = Self.value(
-            MenuBarWindow.self,
-            forKey: Key.menuBarWindow,
+        )
+        trackedProviderIDs = Set(restoredProviders ?? ProviderID.allCases)
+
+        let storedVisibleProviders = Self.decode(
+            [ProviderID].self,
+            forKey: Key.visibleMenuBarProviderIDs,
             in: defaults
-        ) ?? .session
+        )
+        let storedMetricSelections = Self.decode(
+            [ProviderID: [MenuBarMetricID]].self,
+            forKey: Key.menuBarMetricSelections,
+            in: defaults
+        )
+        let storedConfigurationFlag =
+            defaults.object(forKey: Key.hasConfiguredMenuBar) as? Bool
+
+        let currentItems = Self.decode(
+            [MenuBarItemID].self,
+            forKey: Key.currentMenuBarItems,
+            in: defaults
+        )
+        let currentConfigurationFlag =
+            defaults.object(forKey: Key.currentConfiguredMenuBarItems) as? Bool
+        let previousItems = Self.decode(
+            [MenuBarItemID].self,
+            forKey: Key.previousMenuBarItems,
+            in: defaults
+        )
+        let previousConfigurationFlag =
+            defaults.object(forKey: Key.previousConfiguredMenuBarItems) as? Bool
+        let hasLegacyInstallation = Self.hasLegacyInstallation(in: defaults)
+
+        if storedConfigurationFlag == true ||
+            storedVisibleProviders != nil ||
+            storedMetricSelections != nil {
+            visibleMenuBarProviderIDs = Set(
+                storedVisibleProviders ?? []
+            ).intersection(ProviderID.allCases)
+            menuBarMetricSelections = Self.sanitizedSelections(
+                storedMetricSelections ?? [:]
+            )
+            hasConfiguredMenuBar = true
+            pendingMenuBarItems = nil
+        } else if currentConfigurationFlag == true || currentItems != nil {
+            visibleMenuBarProviderIDs = []
+            menuBarMetricSelections = [:]
+            hasConfiguredMenuBar = false
+            pendingMenuBarItems = Self.unique(currentItems ?? [])
+        } else if previousConfigurationFlag == true || previousItems != nil {
+            visibleMenuBarProviderIDs = []
+            menuBarMetricSelections = [:]
+            hasConfiguredMenuBar = false
+            pendingMenuBarItems = Self.unique(previousItems ?? [])
+        } else if hasLegacyInstallation {
+            visibleMenuBarProviderIDs = []
+            menuBarMetricSelections = [:]
+            hasConfiguredMenuBar = false
+            pendingMenuBarItems = nil
+        } else {
+            visibleMenuBarProviderIDs = []
+            menuBarMetricSelections = [:]
+            hasConfiguredMenuBar = false
+            pendingMenuBarItems = nil
+        }
+
+        if let storedCompletion =
+            defaults.object(forKey: Key.hasCompletedInitialSetup) as? Bool {
+            hasCompletedInitialSetup = storedCompletion
+        } else {
+            hasCompletedInitialSetup = hasLegacyInstallation
+        }
+
         usageDisplayMode = Self.value(
             UsageDisplayMode.self,
             forKey: Key.usageDisplayMode,
@@ -53,6 +160,259 @@ final class AppPreferences {
             forKey: Key.refreshInterval,
             in: defaults
         ) ?? .fiveMinutes
+
+        if hasLegacyInstallation &&
+            defaults.object(forKey: Key.hasCompletedInitialSetup) == nil {
+            defaults.set(true, forKey: Key.hasCompletedInitialSetup)
+        }
+    }
+
+    var menuBarProviderConfigurations: [MenuBarProviderConfiguration] {
+        ProviderID.allCases.compactMap { provider in
+            guard visibleMenuBarProviderIDs.contains(provider) else {
+                return nil
+            }
+            return MenuBarProviderConfiguration(
+                provider: provider,
+                metrics: selectedMenuBarMetrics(for: provider)
+            )
+        }
+    }
+
+    func isTracking(_ provider: ProviderID) -> Bool {
+        trackedProviderIDs.contains(provider)
+    }
+
+    func setTracking(_ enabled: Bool, for provider: ProviderID) {
+        if enabled {
+            trackedProviderIDs.insert(provider)
+        } else {
+            trackedProviderIDs.remove(provider)
+            visibleMenuBarProviderIDs.remove(provider)
+        }
+    }
+
+    func isProviderShownInMenuBar(_ provider: ProviderID) -> Bool {
+        visibleMenuBarProviderIDs.contains(provider)
+    }
+
+    func selectedMenuBarMetrics(
+        for provider: ProviderID
+    ) -> [MenuBarMetricID] {
+        menuBarMetricSelections[provider] ?? []
+    }
+
+    func isMenuBarMetricSelected(_ item: MenuBarItemID) -> Bool {
+        selectedMenuBarMetrics(for: item.provider).contains(item.metric)
+    }
+
+    func setMenuBarVisibility(
+        _ enabled: Bool,
+        for provider: ProviderID,
+        availableItems: [MenuBarItemID]
+    ) {
+        if enabled {
+            guard trackedProviderIDs.contains(provider) else { return }
+
+            if selectedMenuBarMetrics(for: provider).isEmpty {
+                guard let defaultMetric = Self.defaultMenuBarItem(
+                    for: provider,
+                    in: availableItems
+                )?.metric else {
+                    return
+                }
+                menuBarMetricSelections[provider] = [defaultMetric]
+            }
+            visibleMenuBarProviderIDs.insert(provider)
+        } else {
+            visibleMenuBarProviderIDs.remove(provider)
+        }
+        hasConfiguredMenuBar = true
+    }
+
+    func setMenuBarMetric(
+        _ enabled: Bool,
+        item: MenuBarItemID,
+        availableItems: [MenuBarItemID]
+    ) {
+        var metrics = selectedMenuBarMetrics(for: item.provider)
+        if enabled {
+            if !metrics.contains(item.metric) {
+                metrics.append(item.metric)
+            }
+            if trackedProviderIDs.contains(item.provider) {
+                visibleMenuBarProviderIDs.insert(item.provider)
+            }
+        } else {
+            metrics.removeAll { $0 == item.metric }
+        }
+
+        metrics = Self.orderedMetrics(
+            metrics,
+            provider: item.provider,
+            availableItems: availableItems
+        )
+        if metrics.isEmpty {
+            menuBarMetricSelections.removeValue(forKey: item.provider)
+            visibleMenuBarProviderIDs.remove(item.provider)
+        } else {
+            menuBarMetricSelections[item.provider] = metrics
+        }
+        hasConfiguredMenuBar = true
+    }
+
+    func configureDefaultMenuBarProviders(
+        availableItemsByProvider: [ProviderID: [MenuBarItemID]]
+    ) {
+        guard !hasConfiguredMenuBar else { return }
+
+        let selectedItems: [MenuBarItemID]
+        if let pendingMenuBarItems {
+            selectedItems = Self.resolve(
+                pendingMenuBarItems,
+                against: availableItemsByProvider
+            )
+        } else {
+            selectedItems = Self.initialWeeklyMenuBarItems
+        }
+        applyMenuBarItems(selectedItems)
+        hasConfiguredMenuBar = true
+    }
+
+    func markInitialSetupCompleted() {
+        guard !hasCompletedInitialSetup else { return }
+        hasCompletedInitialSetup = true
+    }
+
+    private func applyMenuBarItems(_ items: [MenuBarItemID]) {
+        var selections: [ProviderID: [MenuBarMetricID]] = [:]
+        for provider in ProviderID.allCases {
+            let metrics = Self.uniqueMetrics(
+                items
+                    .filter { $0.provider == provider }
+                    .map(\.metric)
+            )
+            if !metrics.isEmpty {
+                selections[provider] = metrics
+            }
+        }
+        menuBarMetricSelections = selections
+        visibleMenuBarProviderIDs = Set(selections.keys)
+    }
+
+    private static var initialWeeklyMenuBarItems: [MenuBarItemID] {
+        ProviderID.allCases.map {
+            MenuBarItemID(provider: $0, metric: .weekly)
+        }
+    }
+
+    private static func hasLegacyInstallation(
+        in defaults: UserDefaults
+    ) -> Bool {
+        [
+            Key.menuBarSelection,
+            Key.menuBarWindow,
+            Key.usageDisplayMode,
+            Key.refreshInterval,
+            "launchAtLoginDefaultActivationApplied"
+        ].contains { defaults.object(forKey: $0) != nil }
+    }
+
+    private static func unique(_ items: [MenuBarItemID]) -> [MenuBarItemID] {
+        var seen: Set<MenuBarItemID> = []
+        return items.filter { seen.insert($0).inserted }
+    }
+
+    private static func uniqueMetrics(
+        _ metrics: [MenuBarMetricID]
+    ) -> [MenuBarMetricID] {
+        var seen: Set<MenuBarMetricID> = []
+        return metrics.filter { seen.insert($0).inserted }
+    }
+
+    private static func sanitizedSelections(
+        _ selections: [ProviderID: [MenuBarMetricID]]
+    ) -> [ProviderID: [MenuBarMetricID]] {
+        Dictionary(uniqueKeysWithValues: ProviderID.allCases.compactMap {
+            provider in
+            let metrics = uniqueMetrics(selections[provider] ?? [])
+            return metrics.isEmpty ? nil : (provider, metrics)
+        })
+    }
+
+    private static func orderedMetrics(
+        _ selectedMetrics: [MenuBarMetricID],
+        provider: ProviderID,
+        availableItems: [MenuBarItemID]
+    ) -> [MenuBarMetricID] {
+        let uniqueSelected = uniqueMetrics(selectedMetrics)
+        let availableOrder = uniqueMetrics(
+            availableItems
+                .filter { $0.provider == provider }
+                .map(\.metric)
+        )
+        let available = availableOrder.filter(uniqueSelected.contains)
+        let temporarilyUnavailable = uniqueSelected.filter {
+            !availableOrder.contains($0)
+        }
+        return available + temporarilyUnavailable
+    }
+
+    private static func defaultMenuBarItem(
+        for provider: ProviderID,
+        in availableItems: [MenuBarItemID]
+    ) -> MenuBarItemID? {
+        let providerItems = availableItems.filter {
+            $0.provider == provider
+        }
+        return providerItems.first {
+            $0.metric == .weekly
+        } ?? providerItems.first
+    }
+
+    private static func resolve(
+        _ desiredItems: [MenuBarItemID],
+        against availableItemsByProvider: [ProviderID: [MenuBarItemID]]
+    ) -> [MenuBarItemID] {
+        var resolved: [MenuBarItemID] = []
+        for provider in ProviderID.allCases {
+            let desiredForProvider = desiredItems.filter {
+                $0.provider == provider
+            }
+            guard !desiredForProvider.isEmpty else { continue }
+
+            let available = availableItemsByProvider[provider] ?? []
+            if available.isEmpty {
+                resolved.append(contentsOf: desiredForProvider)
+                continue
+            }
+            let desiredSet = Set(desiredForProvider)
+            let exactMatches = available.filter(desiredSet.contains)
+            if exactMatches.isEmpty {
+                if let fallback = defaultMenuBarItem(
+                    for: provider,
+                    in: available
+                ) {
+                    resolved.append(fallback)
+                }
+            } else {
+                resolved.append(contentsOf: exactMatches)
+            }
+        }
+        return unique(resolved)
+    }
+
+    private static func encode<Value: Encodable>(_ value: Value) -> Data? {
+        try? JSONEncoder().encode(value)
+    }
+
+    private static func decode<Value: Decodable>(
+        _ type: Value.Type,
+        forKey key: String,
+        in defaults: UserDefaults
+    ) -> Value? {
+        guard let data = defaults.data(forKey: key) else { return nil }
+        return try? JSONDecoder().decode(type, from: data)
     }
 
     private static func value<Value: RawRepresentable>(
@@ -65,6 +425,20 @@ final class AppPreferences {
     }
 
     private enum Key {
+        static let trackedProviderIDs = "trackedProviderIDs.v1"
+        static let visibleMenuBarProviderIDs =
+            "menuBarVisibleProviders.v3"
+        static let menuBarMetricSelections =
+            "menuBarMetricSelections.v3"
+        static let hasConfiguredMenuBar =
+            "menuBarConfigured.v3"
+        static let currentMenuBarItems = "menuBarItems.v2"
+        static let currentConfiguredMenuBarItems =
+            "menuBarItemsConfigured.v2"
+        static let previousMenuBarItems = "menuBarItems.v1"
+        static let previousConfiguredMenuBarItems =
+            "menuBarItemsConfigured.v1"
+        static let hasCompletedInitialSetup = "initialSettingsCompleted.v1"
         static let menuBarSelection = "menuBarSelection"
         static let menuBarWindow = "menuBarWindow"
         static let usageDisplayMode = "usageDisplayMode"

--- a/AIUsage/Store/UsageStore.swift
+++ b/AIUsage/Store/UsageStore.swift
@@ -2,17 +2,42 @@ import Foundation
 import Observation
 
 struct MenuBarReading: Equatable, Sendable {
-    let provider: ProviderID?
-    let percent: Double?
+    let provider: ProviderID
+    let metric: MenuBarMetricID
+    let value: MenuBarReadingValue
     let displayMode: UsageDisplayMode
     let isStale: Bool
-    let showsPlaceholder: Bool
+
+    init(
+        provider: ProviderID,
+        metric: MenuBarMetricID,
+        value: MenuBarReadingValue,
+        displayMode: UsageDisplayMode,
+        isStale: Bool
+    ) {
+        self.provider = provider
+        self.metric = metric
+        self.value = value
+        self.displayMode = displayMode
+        self.isStale = isStale
+    }
+}
+
+struct MenuBarProviderReadings: Equatable, Identifiable, Sendable {
+    let provider: ProviderID
+    let selectedMetrics: [MenuBarMetricID]
+    let readings: [MenuBarReading]
+
+    var id: ProviderID { provider }
+    var showsMetricLabels: Bool { selectedMetrics.count > 1 }
 }
 
 @MainActor
 @Observable
 final class UsageStore {
     private(set) var states: [ProviderID: ProviderState]
+    private(set) var installedProviderIDs: Set<ProviderID>?
+    private(set) var trackedProviderIDs: Set<ProviderID>
     private(set) var lastAttemptAt: Date?
     private(set) var lastSuccessfulRefreshAt: Date?
     private(set) var refreshInterval: RefreshIntervalOption
@@ -20,17 +45,20 @@ final class UsageStore {
     private let providers: [any UsageProvider]
     private let availabilityChecker: any ProviderAvailabilityChecking
     private var cadenceTask: Task<Void, Never>?
-    private var refreshTask: Task<RefreshResult, Never>?
+    private var refreshTask: Task<Void, Never>?
+    private var refreshGeneration = 0
 
     init(
         providers: [any UsageProvider] = [ClaudeProvider(), CodexProvider()],
         availabilityChecker: any ProviderAvailabilityChecking =
             SystemProviderAvailabilityChecker(),
-        refreshInterval: RefreshIntervalOption = .fiveMinutes
+        refreshInterval: RefreshIntervalOption = .fiveMinutes,
+        trackedProviderIDs: Set<ProviderID> = Set(ProviderID.allCases)
     ) {
         self.providers = providers
         self.availabilityChecker = availabilityChecker
         self.refreshInterval = refreshInterval
+        self.trackedProviderIDs = trackedProviderIDs
         states = Dictionary(uniqueKeysWithValues: ProviderID.allCases.map {
             ($0, ProviderState(provider: $0))
         })
@@ -45,8 +73,26 @@ final class UsageStore {
     func stop() {
         cadenceTask?.cancel()
         cadenceTask = nil
-        refreshTask?.cancel()
-        refreshTask = nil
+        cancelRefresh()
+    }
+
+    func setTrackedProviders(_ providers: Set<ProviderID>) {
+        guard trackedProviderIDs != providers else { return }
+
+        let newlyEnabled = providers.subtracting(trackedProviderIDs)
+        trackedProviderIDs = providers
+        for provider in ProviderID.allCases where !providers.contains(provider) {
+            states[provider]?.isRefreshing = false
+        }
+
+        guard cadenceTask != nil else { return }
+        cadenceTask?.cancel()
+        cadenceTask = nil
+        cancelRefresh()
+        cadenceTask = makeCadenceTask(
+            refreshImmediately: !newlyEnabled.isEmpty,
+            initialProviderIDs: newlyEnabled.isEmpty ? nil : newlyEnabled
+        )
     }
 
     func setRefreshInterval(_ interval: RefreshIntervalOption) {
@@ -61,30 +107,43 @@ final class UsageStore {
     func refreshNow() {
         cadenceTask?.cancel()
         cadenceTask = nil
-        Task { [weak self] in
-            guard let self else { return }
-            await self.refresh()
-            guard !Task.isCancelled else { return }
-            self.cadenceTask = self.makeCadenceTask(refreshImmediately: false)
-        }
+        cancelRefresh()
+        cadenceTask = makeCadenceTask(refreshImmediately: true)
     }
 
-    func refresh() async {
+    func refresh(providerIDs requestedProviderIDs: Set<ProviderID>? = nil) async {
         if let refreshTask {
-            _ = await refreshTask.value
+            await refreshTask.value
             return
         }
 
-        for provider in providers {
-            states[provider.id]?.isRefreshing = true
-        }
+        refreshGeneration += 1
+        let generation = refreshGeneration
         let providers = self.providers
+        let trackedProviderIDs = self.trackedProviderIDs
         let availabilityChecker = self.availabilityChecker
-        let task = Task {
-            async let installedProviders =
-                availabilityChecker.installedProviders()
-            let fetchResults = await withTaskGroup(of: FetchResult.self) { group in
-                for provider in providers {
+        let task = Task { [weak self] in
+            let installedProviders =
+                await availabilityChecker.installedProviders()
+            guard !Task.isCancelled else { return }
+
+            self?.applyInstalledProviders(installedProviders)
+
+            let requested = requestedProviderIDs ?? trackedProviderIDs
+            let effectiveProviders = providers.filter { provider in
+                trackedProviderIDs.contains(provider.id) &&
+                    requested.contains(provider.id) &&
+                    (installedProviders?.contains(provider.id) ?? true)
+            }
+
+            for provider in effectiveProviders {
+                self?.states[provider.id]?.isRefreshing = true
+            }
+
+            let fetchResults = await withTaskGroup(
+                of: FetchResult.self
+            ) { group in
+                for provider in effectiveProviders {
                     group.addTask {
                         do {
                             return FetchResult(
@@ -92,7 +151,10 @@ final class UsageStore {
                                 result: .success(try await provider.fetch())
                             )
                         } catch let failure as ProviderFailure {
-                            return FetchResult(provider: provider.id, result: .failure(failure))
+                            return FetchResult(
+                                provider: provider.id,
+                                result: .failure(failure)
+                            )
                         } catch {
                             return FetchResult(
                                 provider: provider.id,
@@ -111,24 +173,125 @@ final class UsageStore {
                 }
                 return results
             }
-            return RefreshResult(
-                fetchResults: fetchResults,
-                installedProviders: await installedProviders
-            )
+
+            guard !Task.isCancelled else { return }
+            self?.applyFetchResults(fetchResults)
         }
         refreshTask = task
-        let result = await task.value
-        refreshTask = nil
+        await task.value
+        if generation == refreshGeneration {
+            refreshTask = nil
+        }
+    }
 
-        lastAttemptAt = Date()
-        if let installedProviders = result.installedProviders {
-            for provider in ProviderID.allCases {
-                states[provider]?.isToolInstalled =
-                    installedProviders.contains(provider)
+    func isProviderVisibleInDashboard(_ provider: ProviderID) -> Bool {
+        trackedProviderIDs.contains(provider) &&
+            states[provider]?.isToolInstalled != false
+    }
+
+    func availableMenuBarItems(
+        for provider: ProviderID
+    ) -> [MenuBarItemID] {
+        guard trackedProviderIDs.contains(provider),
+              states[provider]?.isToolInstalled != false else {
+            return []
+        }
+        return states[provider]?.snapshot?.availableMenuBarItems ?? []
+    }
+
+    var availableMenuBarItemsByProvider:
+        [ProviderID: [MenuBarItemID]] {
+        Dictionary(uniqueKeysWithValues: ProviderID.allCases.map {
+            ($0, availableMenuBarItems(for: $0))
+        })
+    }
+
+    func isMenuBarItemAvailable(_ item: MenuBarItemID) -> Bool {
+        availableMenuBarItems(for: item.provider).contains(item)
+    }
+
+    func menuBarReadings(
+        for items: [MenuBarItemID],
+        displayMode: UsageDisplayMode = .used
+    ) -> [MenuBarReading] {
+        items.compactMap { item in
+            guard trackedProviderIDs.contains(item.provider),
+                  let state = states[item.provider],
+                  state.isToolInstalled != false,
+                  let value = state.snapshot?.menuBarValue(
+                    for: item.metric,
+                    displayMode: displayMode
+                  ) else {
+                return nil
+            }
+
+            return MenuBarReading(
+                provider: item.provider,
+                metric: item.metric,
+                value: value,
+                displayMode: displayMode,
+                isStale: state.isStale
+            )
+        }
+    }
+
+    func menuBarProviderReadings(
+        for configurations: [MenuBarProviderConfiguration],
+        displayMode: UsageDisplayMode = .used
+    ) -> [MenuBarProviderReadings] {
+        configurations.compactMap { configuration in
+            guard trackedProviderIDs.contains(configuration.provider),
+                  let state = states[configuration.provider],
+                  state.isToolInstalled != false else {
+                return nil
+            }
+
+            let items = configuration.metrics.map {
+                MenuBarItemID(
+                    provider: configuration.provider,
+                    metric: $0
+                )
+            }
+            return MenuBarProviderReadings(
+                provider: configuration.provider,
+                selectedMetrics: configuration.metrics,
+                readings: menuBarReadings(
+                    for: items,
+                    displayMode: displayMode
+                )
+            )
+        }
+    }
+
+    func menuBarReading(
+        for item: MenuBarItemID,
+        displayMode: UsageDisplayMode = .used
+    ) -> MenuBarReading? {
+        menuBarReadings(for: [item], displayMode: displayMode).first
+    }
+
+    private func applyInstalledProviders(_ installedProviders: Set<ProviderID>?) {
+        installedProviderIDs = installedProviders
+        guard let installedProviders else { return }
+
+        for provider in ProviderID.allCases {
+            states[provider]?.isToolInstalled =
+                installedProviders.contains(provider)
+            if !installedProviders.contains(provider) {
+                states[provider]?.isRefreshing = false
             }
         }
+    }
+
+    private func applyFetchResults(_ fetchResults: [FetchResult]) {
+        lastAttemptAt = Date()
         var successfulDates: [Date] = []
-        for fetchResult in result.fetchResults {
+
+        for fetchResult in fetchResults {
+            guard trackedProviderIDs.contains(fetchResult.provider) else {
+                continue
+            }
+
             var state =
                 states[fetchResult.provider] ??
                 ProviderState(provider: fetchResult.provider)
@@ -146,113 +309,26 @@ final class UsageStore {
             }
             states[fetchResult.provider] = state
         }
+
         if let latest = successfulDates.max() {
             lastSuccessfulRefreshAt = latest
         }
     }
 
-    func menuBarReadings(
-        for selection: MenuBarSelection,
-        window windowSelection: MenuBarWindow = .session,
-        displayMode: UsageDisplayMode = .used
-    ) -> [MenuBarReading] {
-        guard selection == .all else {
-            return [
-                menuBarReading(
-                    for: selection,
-                    window: windowSelection,
-                    displayMode: displayMode
-                )
-            ]
-        }
-
-        return ProviderID.allCases.compactMap { provider in
-            guard states[provider]?.isVisibleInDashboard != false else {
-                return nil
-            }
-            let pinnedSelection: MenuBarSelection
-            switch provider {
-            case .claude:
-                pinnedSelection = .claude
-            case .codex:
-                pinnedSelection = .codex
-            }
-            return menuBarReading(
-                for: pinnedSelection,
-                window: windowSelection,
-                displayMode: displayMode
-            )
-        }
+    private func cancelRefresh() {
+        refreshGeneration += 1
+        refreshTask?.cancel()
+        refreshTask = nil
     }
 
-    func menuBarReading(
-        for selection: MenuBarSelection,
-        window windowSelection: MenuBarWindow = .session,
-        displayMode: UsageDisplayMode = .used
-    ) -> MenuBarReading {
-        switch selection {
-        case .automatic:
-            let candidates = ProviderID.allCases.compactMap { provider -> (ProviderID, Double, Bool)? in
-                guard let state = states[provider],
-                      let value = state.snapshot?
-                        .primaryWindow(for: windowSelection)?
-                        .usedPercent else {
-                    return nil
-                }
-                return (provider, value, state.isStale)
-            }
-            guard let highest = candidates.max(by: { $0.1 < $1.1 }) else {
-                return MenuBarReading(
-                    provider: nil,
-                    percent: nil,
-                    displayMode: displayMode,
-                    isStale: false,
-                    showsPlaceholder: false
-                )
-            }
-            return MenuBarReading(
-                provider: highest.0,
-                percent: displayMode.displayedPercent(from: highest.1),
-                displayMode: displayMode,
-                isStale: highest.2,
-                showsPlaceholder: false
-            )
-
-        case .all:
-            return menuBarReadings(
-                for: .all,
-                window: windowSelection,
-                displayMode: displayMode
-            ).first ?? MenuBarReading(
-                provider: nil,
-                percent: nil,
-                displayMode: displayMode,
-                isStale: false,
-                showsPlaceholder: false
-            )
-
-        case .claude, .codex:
-            let provider: ProviderID = selection == .claude ? .claude : .codex
-            let state = states[provider]
-            let window = state?.snapshot?
-                .primaryWindowWithFallback(for: windowSelection)
-            return MenuBarReading(
-                provider: provider,
-                percent: window.map {
-                    displayMode.displayedPercent(from: $0.usedPercent)
-                },
-                displayMode: displayMode,
-                isStale: state?.isStale == true,
-                showsPlaceholder: window == nil
-            )
-        }
-    }
-
-    private func makeCadenceTask(refreshImmediately: Bool) -> Task<Void, Never> {
+    private func makeCadenceTask(
+        refreshImmediately: Bool,
+        initialProviderIDs: Set<ProviderID>? = nil
+    ) -> Task<Void, Never> {
         let duration = refreshInterval.duration
         return Task { [weak self, duration] in
             if refreshImmediately {
-                await self?.refresh()
+                await self?.refresh(providerIDs: initialProviderIDs)
             }
             while !Task.isCancelled {
                 do {
@@ -270,9 +346,4 @@ final class UsageStore {
 private struct FetchResult: Sendable {
     let provider: ProviderID
     let result: Result<ProviderSnapshot, ProviderFailure>
-}
-
-private struct RefreshResult: Sendable {
-    let fetchResults: [FetchResult]
-    let installedProviders: Set<ProviderID>?
 }

--- a/AIUsage/Store/UsageStore.swift
+++ b/AIUsage/Store/UsageStore.swift
@@ -151,6 +151,40 @@ final class UsageStore {
         }
     }
 
+    func menuBarReadings(
+        for selection: MenuBarSelection,
+        window windowSelection: MenuBarWindow = .session,
+        displayMode: UsageDisplayMode = .used
+    ) -> [MenuBarReading] {
+        guard selection == .all else {
+            return [
+                menuBarReading(
+                    for: selection,
+                    window: windowSelection,
+                    displayMode: displayMode
+                )
+            ]
+        }
+
+        return ProviderID.allCases.compactMap { provider in
+            guard states[provider]?.isVisibleInDashboard != false else {
+                return nil
+            }
+            let pinnedSelection: MenuBarSelection
+            switch provider {
+            case .claude:
+                pinnedSelection = .claude
+            case .codex:
+                pinnedSelection = .codex
+            }
+            return menuBarReading(
+                for: pinnedSelection,
+                window: windowSelection,
+                displayMode: displayMode
+            )
+        }
+    }
+
     func menuBarReading(
         for selection: MenuBarSelection,
         window windowSelection: MenuBarWindow = .session,
@@ -181,6 +215,19 @@ final class UsageStore {
                 percent: displayMode.displayedPercent(from: highest.1),
                 displayMode: displayMode,
                 isStale: highest.2,
+                showsPlaceholder: false
+            )
+
+        case .all:
+            return menuBarReadings(
+                for: .all,
+                window: windowSelection,
+                displayMode: displayMode
+            ).first ?? MenuBarReading(
+                provider: nil,
+                percent: nil,
+                displayMode: displayMode,
+                isStale: false,
                 showsPlaceholder: false
             )
 

--- a/AIUsage/Views/DashboardView.swift
+++ b/AIUsage/Views/DashboardView.swift
@@ -4,13 +4,12 @@ import SwiftUI
 struct DashboardView: View {
     @Bindable var store: UsageStore
     @Bindable var launchAtLogin: LaunchAtLoginController
-    @Binding var menuBarSelection: MenuBarSelection
-    @Binding var menuBarWindow: MenuBarWindow
     @Binding var usageDisplayMode: UsageDisplayMode
     @Binding var refreshInterval: RefreshIntervalOption
     let availableUpdateVersion: String?
     let isCheckingForUpdates: Bool
     var checkForUpdates: @MainActor () -> Void = {}
+    var openSettings: @MainActor () -> Void = {}
 
     var body: some View {
         GlassEffectContainer(spacing: 10) {
@@ -79,85 +78,12 @@ struct DashboardView: View {
                 .help(isRefreshing ? "Refreshing usage" : "Refresh now")
                 .disabled(isRefreshing)
 
-                Menu {
-                    Picker("Menu Bar Provider", selection: $menuBarSelection) {
-                        ForEach(MenuBarSelection.allCases) { option in
-                            Label {
-                                Text(option.title)
-                            } icon: {
-                                if let provider = option.provider {
-                                    ProviderIcon(provider: provider, size: 13)
-                                } else if option == .all {
-                                    Image(systemName: "rectangle.3.group")
-                                } else {
-                                    Image(systemName: "gauge.with.dots.needle.50percent")
-                                }
-                            }
-                            .tag(option)
-                        }
-                    }
-
-                    Picker("Menu Bar Period", selection: $menuBarWindow) {
-                        ForEach(MenuBarWindow.allCases) { option in
-                            Label(
-                                option.title,
-                                systemImage: option == .session
-                                    ? "clock"
-                                    : "calendar"
-                            )
-                            .tag(option)
-                        }
-                    }
-
-                    Picker("Refresh", selection: $refreshInterval) {
-                        ForEach(RefreshIntervalOption.allCases) { option in
-                            Text(option.title)
-                                .tag(option)
-                        }
-                    }
-
-                    Divider()
-
-                    Toggle(
-                        "Launch at Login",
-                        isOn: Binding(
-                            get: { launchAtLogin.isEnabled },
-                            set: { launchAtLogin.setEnabled($0) }
-                        )
-                    )
-
-                    if launchAtLogin.requiresApproval {
-                        Text("Approval needed in System Settings")
-                    }
-                    if let error = launchAtLogin.errorMessage {
-                        Text(error)
-                    }
-
-                    Divider()
-
-                    Button(action: checkForUpdates) {
-                        Label(
-                            "Check for Updates…",
-                            systemImage: "arrow.triangle.2.circlepath"
-                        )
-                    }
-                    .disabled(isCheckingForUpdates)
-
-                    Link(destination: AppLinks.repository) {
-                        Label("Star AI Usage on GitHub", systemImage: "star")
-                    }
-
-                    Button("Quit AI Usage") {
-                        NSApplication.shared.terminate(nil)
-                    }
-                } label: {
+                Button(action: openSettings) {
                     SettingsButtonLabel()
                 }
-                .menuStyle(.button)
-                .menuIndicator(.hidden)
                 .help("Settings")
                 .accessibilityLabel("Settings")
-                .accessibilityHint("Opens preferences and app actions")
+                .accessibilityHint("Shows settings in the menu bar panel")
             }
             .buttonStyle(.plain)
             .glassEffect(.regular, in: .capsule)
@@ -225,7 +151,7 @@ struct DashboardContentView: View {
             header
             ForEach(ProviderID.allCases) { provider in
                 if let state = store.states[provider],
-                   state.isVisibleInDashboard {
+                   store.isProviderVisibleInDashboard(provider) {
                     ProviderSectionView(
                         state: state,
                         displayMode: usageDisplayMode

--- a/AIUsage/Views/DashboardView.swift
+++ b/AIUsage/Views/DashboardView.swift
@@ -87,6 +87,8 @@ struct DashboardView: View {
                             } icon: {
                                 if let provider = option.provider {
                                     ProviderIcon(provider: provider, size: 13)
+                                } else if option == .all {
+                                    Image(systemName: "rectangle.3.group")
                                 } else {
                                     Image(systemName: "gauge.with.dots.needle.50percent")
                                 }

--- a/AIUsage/Views/MenuBarLabelView.swift
+++ b/AIUsage/Views/MenuBarLabelView.swift
@@ -6,25 +6,43 @@ struct MenuBarPresentation: Equatable, Sendable {
     let showsStaleIndicator: Bool
 
     init(reading: MenuBarReading) {
-        if let percent = reading.percent {
+        let provider = reading.provider.displayName
+        let subject = "\(provider) \(reading.metric.title)"
+        switch reading.value {
+        case .percentage(let percent):
             valueText = "\(Int(percent.rounded()))%"
-        } else if reading.showsPlaceholder {
-            valueText = "--"
-        } else {
-            valueText = nil
-        }
-
-        let subject = reading.provider?.displayName ?? "AI usage"
-        if let percent = reading.percent {
             let value =
                 "\(Int(percent.rounded())) percent \(reading.displayMode.valueSuffix)"
             accessibilityLabel = reading.isStale
                 ? "\(subject) \(value), stale"
                 : "\(subject) \(value)"
-        } else {
-            accessibilityLabel = subject
+        case let .money(amount, currencyCode):
+            let formatted = Self.currency(amount, code: currencyCode)
+            valueText = formatted
+            let qualifier = reading.displayMode == .used ? "spent" : "left"
+            accessibilityLabel = reading.isStale
+                ? "\(subject) \(formatted) \(qualifier), stale"
+                : "\(subject) \(formatted) \(qualifier)"
+        case let .credits(remaining, usdValue):
+            let formatted = Self.currency(usdValue, code: "USD")
+            valueText = formatted
+            let detail = "\(remaining) credits left, worth \(formatted)"
+            accessibilityLabel = reading.isStale
+                ? "\(subject) \(detail), stale"
+                : "\(subject) \(detail)"
         }
         showsStaleIndicator = reading.isStale
+    }
+
+    private static func currency(_ amount: Double, code: String) -> String {
+        let formatter = NumberFormatter()
+        formatter.locale = .current
+        formatter.numberStyle = .currency
+        formatter.currencyCode = code
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 2
+        return formatter.string(from: NSNumber(value: amount))
+            ?? "\(amount.formatted(.number.precision(.fractionLength(0...2)))) \(code)"
     }
 }
 
@@ -38,29 +56,137 @@ struct MenuBarReadingsPresentation: Equatable, Sendable {
             ? "AI usage"
             : items.map(\.accessibilityLabel).joined(separator: ", ")
     }
+
+    init(groups: [MenuBarProviderReadings]) {
+        items = groups
+            .flatMap(\.readings)
+            .map(MenuBarPresentation.init(reading:))
+        guard !groups.isEmpty else {
+            accessibilityLabel = "AI usage"
+            return
+        }
+        accessibilityLabel = groups.map { group in
+            if group.readings.isEmpty {
+                return "\(group.provider.displayName), no usage data"
+            }
+            return group.readings
+                .map(MenuBarPresentation.init(reading:))
+                .map(\.accessibilityLabel)
+                .joined(separator: ", ")
+        }.joined(separator: ", ")
+    }
 }
 
-struct MenuBarLabelView: View {
-    let reading: MenuBarReading
+struct MenuBarMetricPresentation: Equatable, Sendable {
+    let label: String?
+    let valueText: String
+    let showsStaleIndicator: Bool
+}
+
+struct MenuBarProviderPresentation: Equatable, Sendable {
+    let provider: ProviderID
+    let metrics: [MenuBarMetricPresentation]
+    let sharedSuffix: String?
+
+    init(group: MenuBarProviderReadings) {
+        provider = group.provider
+        let sharesPercentageSuffix =
+            group.showsMetricLabels &&
+            !group.readings.isEmpty &&
+            group.readings.allSatisfy { reading in
+                if case .percentage = reading.value {
+                    return true
+                }
+                return false
+            }
+
+        metrics = group.readings.compactMap { reading in
+            let presentation = MenuBarPresentation(reading: reading)
+            guard var valueText = presentation.valueText,
+                  !valueText.isEmpty else {
+                return nil
+            }
+
+            if sharesPercentageSuffix,
+               case .percentage(let percent) = reading.value {
+                valueText = "\(Int(percent.rounded()))"
+            }
+
+            return MenuBarMetricPresentation(
+                label: group.showsMetricLabels
+                    ? reading.metric.compactLabel
+                    : nil,
+                valueText: valueText,
+                showsStaleIndicator:
+                    presentation.showsStaleIndicator
+            )
+        }
+        sharedSuffix = sharesPercentageSuffix ? "%" : nil
+    }
+}
+
+struct MenuBarProviderLabelView: View {
+    let group: MenuBarProviderReadings
+    private let microFontSize: CGFloat = 8
 
     var body: some View {
-        let presentation = MenuBarPresentation(reading: reading)
+        let presentation = MenuBarProviderPresentation(group: group)
 
         HStack(spacing: 4) {
-            if let provider = reading.provider {
-                ProviderIcon(provider: provider, size: 15)
-            } else {
-                Image(systemName: "gauge.with.dots.needle.50percent")
-            }
-            if let valueText = presentation.valueText {
-                Text(valueText)
-                    .monospacedDigit()
-            }
-            if presentation.showsStaleIndicator {
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .font(.caption2)
+            ProviderIcon(provider: group.provider, size: 15)
+
+            HStack(spacing: 0) {
+                ForEach(
+                    Array(presentation.metrics.enumerated()),
+                    id: \.offset
+                ) { index, metric in
+                    if index > 0 {
+                        Text("·")
+                            .font(.system(
+                                size: microFontSize,
+                                weight: .semibold
+                            ))
+                            .padding(.horizontal, 3)
+                    }
+
+                    if let label = metric.label {
+                        Text(label)
+                            .font(.system(
+                                size: microFontSize,
+                                weight: .semibold
+                            ))
+                            .baselineOffset(2)
+                            .padding(.trailing, 1)
+                    }
+
+                    Text(metric.valueText)
+                        .monospacedDigit()
+
+                    if index == presentation.metrics.count - 1,
+                       let suffix = presentation.sharedSuffix {
+                        Text(suffix)
+                            .font(.system(
+                                size: microFontSize,
+                                weight: .semibold
+                            ))
+                            .padding(.leading, 1)
+                    }
+
+                    if metric.showsStaleIndicator {
+                        Text("⚠︎")
+                            .font(.system(
+                                size: microFontSize,
+                                weight: .semibold
+                            ))
+                            .padding(.leading, 1)
+                    }
+                }
             }
         }
-        .accessibilityLabel(presentation.accessibilityLabel)
+        .accessibilityLabel(
+            MenuBarReadingsPresentation(
+                groups: [group]
+            ).accessibilityLabel
+        )
     }
 }

--- a/AIUsage/Views/MenuBarLabelView.swift
+++ b/AIUsage/Views/MenuBarLabelView.swift
@@ -28,6 +28,18 @@ struct MenuBarPresentation: Equatable, Sendable {
     }
 }
 
+struct MenuBarReadingsPresentation: Equatable, Sendable {
+    let items: [MenuBarPresentation]
+    let accessibilityLabel: String
+
+    init(readings: [MenuBarReading]) {
+        items = readings.map(MenuBarPresentation.init(reading:))
+        accessibilityLabel = items.isEmpty
+            ? "AI usage"
+            : items.map(\.accessibilityLabel).joined(separator: ", ")
+    }
+}
+
 struct MenuBarLabelView: View {
     let reading: MenuBarReading
 

--- a/AIUsage/Views/ProviderSectionView.swift
+++ b/AIUsage/Views/ProviderSectionView.swift
@@ -17,7 +17,7 @@ struct ProviderSectionView: View {
         VStack(alignment: .leading, spacing: 0) {
             providerHeader
             if let snapshot = state.snapshot,
-               !snapshot.windows.isEmpty || snapshot.creditUsage != nil {
+               !snapshot.windows.isEmpty || snapshot.billingUsage != nil {
                 if !snapshot.windows.isEmpty {
                     QuotaGrid(
                         windows: snapshot.windows,
@@ -26,8 +26,11 @@ struct ProviderSectionView: View {
                     .padding(.horizontal, 10)
                     .padding(.bottom, 6)
                 }
-                if let creditUsage = snapshot.creditUsage {
-                    CreditUsageRow(usage: creditUsage)
+                if let billingUsage = snapshot.billingUsage {
+                    BillingUsageRow(
+                        usage: billingUsage,
+                        displayMode: displayMode
+                    )
                 }
             } else if state.isRefreshing {
                 ProviderStatusRow(
@@ -86,66 +89,123 @@ struct ProviderSectionView: View {
     }
 }
 
-private struct CreditUsageRow: View {
-    let usage: CreditUsage
+struct BillingUsagePresentation: Equatable {
+    let title: String
+    let valueText: String
+    let accessibilityValue: String
+
+    init(
+        usage: BillingUsage,
+        displayMode: UsageDisplayMode,
+        locale: Locale = .current
+    ) {
+        switch usage {
+        case let .boundedSpend(usedAmount, limitAmount, currencyCode):
+            let displayedAmount: Double
+            let suffix: String
+            switch displayMode {
+            case .used:
+                displayedAmount = usedAmount
+                suffix = "spent"
+            case .remaining:
+                displayedAmount = max(limitAmount - usedAmount, 0)
+                suffix = "left"
+            }
+            let displayed = Self.currency(
+                displayedAmount,
+                code: currencyCode,
+                locale: locale
+            )
+            let limit = Self.currency(
+                limitAmount,
+                code: currencyCode,
+                locale: locale
+            )
+            title = "Extra usage"
+            valueText = "\(displayed) / \(limit) \(suffix)"
+            accessibilityValue = "\(displayed) \(suffix), \(limit) monthly limit"
+
+        case let .unboundedSpend(usedAmount, currencyCode):
+            let used = Self.currency(
+                usedAmount,
+                code: currencyCode,
+                locale: locale
+            )
+            title = "Extra usage"
+            valueText = "\(used) spent"
+            accessibilityValue = "\(used) spent, no monthly limit"
+
+        case let .flexCreditBalance(remainingCredits, usdValue):
+            let value = Self.currency(
+                usdValue,
+                code: "USD",
+                locale: locale
+            )
+            let credits = Self.integer(remainingCredits, locale: locale)
+            title = "Credits"
+            valueText = "\(value) · \(credits) credits left"
+            accessibilityValue =
+                "\(credits) Codex credits remaining, worth \(value)"
+        }
+    }
+
+    private static func currency(
+        _ amount: Double,
+        code: String,
+        locale: Locale
+    ) -> String {
+        let formatter = NumberFormatter()
+        formatter.locale = locale
+        formatter.numberStyle = .currency
+        formatter.currencyCode = code
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 2
+        return formatter.string(from: NSNumber(value: amount)) ?? "\(amount)"
+    }
+
+    private static func integer(_ value: Int, locale: Locale) -> String {
+        let formatter = NumberFormatter()
+        formatter.locale = locale
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 0
+        return formatter.string(from: NSNumber(value: value)) ?? "\(value)"
+    }
+}
+
+private struct BillingUsageRow: View {
+    let usage: BillingUsage
+    let displayMode: UsageDisplayMode
 
     var body: some View {
+        let presentation = BillingUsagePresentation(
+            usage: usage,
+            displayMode: displayMode
+        )
+
         HStack(spacing: 7) {
             Image(systemName: "creditcard")
                 .symbolRenderingMode(.hierarchical)
                 .foregroundStyle(.tertiary)
                 .frame(width: 14, height: 14)
 
-            Text("Credits")
+            Text(presentation.title)
                 .foregroundStyle(.secondary)
 
             Spacer(minLength: 8)
 
-            Text(valueText)
+            Text(presentation.valueText)
                 .monospacedDigit()
                 .fontWeight(.medium)
                 .lineLimit(1)
-                .minimumScaleFactor(0.8)
+                .minimumScaleFactor(0.75)
         }
         .font(.caption)
         .frame(maxWidth: .infinity, minHeight: 24)
         .padding(.horizontal, 14)
         .padding(.bottom, 8)
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("Credits")
-        .accessibilityValue(valueText)
-    }
-
-    private var valueText: String {
-        if usage.isUnlimited {
-            return "Unlimited"
-        }
-        if let balance = usage.balanceAmount {
-            return "\(currency(balance)) left"
-        }
-        if let remaining = usage.remainingAmount {
-            return "\(currency(remaining)) left"
-        }
-        if let used = usage.usedAmount {
-            return "\(currency(used)) used"
-        }
-        if let limit = usage.limitAmount {
-            return "\(currency(limit)) limit"
-        }
-        if let percent = usage.usedPercent {
-            let formatted = percent.formatted(
-                .number.precision(.fractionLength(0...1))
-            )
-            return "\(formatted)% used"
-        }
-        return "Available"
-    }
-
-    private func currency(_ amount: Double) -> String {
-        amount.formatted(
-            .currency(code: usage.currencyCode)
-                .precision(.fractionLength(2))
-        )
+        .accessibilityLabel(presentation.title)
+        .accessibilityValue(presentation.accessibilityValue)
     }
 }
 

--- a/AIUsage/Views/ProviderSectionView.swift
+++ b/AIUsage/Views/ProviderSectionView.swift
@@ -16,13 +16,19 @@ struct ProviderSectionView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             providerHeader
-            if let snapshot = state.snapshot, !snapshot.windows.isEmpty {
-                QuotaGrid(
-                    windows: snapshot.windows,
-                    displayMode: displayMode
-                )
-                .padding(.horizontal, 10)
-                .padding(.bottom, 6)
+            if let snapshot = state.snapshot,
+               !snapshot.windows.isEmpty || snapshot.creditUsage != nil {
+                if !snapshot.windows.isEmpty {
+                    QuotaGrid(
+                        windows: snapshot.windows,
+                        displayMode: displayMode
+                    )
+                    .padding(.horizontal, 10)
+                    .padding(.bottom, 6)
+                }
+                if let creditUsage = snapshot.creditUsage {
+                    CreditUsageRow(usage: creditUsage)
+                }
             } else if state.isRefreshing {
                 ProviderStatusRow(
                     message: "Checking local login…",
@@ -77,6 +83,69 @@ struct ProviderSectionView: View {
         .padding(.horizontal, 14)
         .padding(.top, 10)
         .padding(.bottom, 6)
+    }
+}
+
+private struct CreditUsageRow: View {
+    let usage: CreditUsage
+
+    var body: some View {
+        HStack(spacing: 7) {
+            Image(systemName: "creditcard")
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(.tertiary)
+                .frame(width: 14, height: 14)
+
+            Text("Credits")
+                .foregroundStyle(.secondary)
+
+            Spacer(minLength: 8)
+
+            Text(valueText)
+                .monospacedDigit()
+                .fontWeight(.medium)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+        }
+        .font(.caption)
+        .frame(maxWidth: .infinity, minHeight: 24)
+        .padding(.horizontal, 14)
+        .padding(.bottom, 8)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Credits")
+        .accessibilityValue(valueText)
+    }
+
+    private var valueText: String {
+        if usage.isUnlimited {
+            return "Unlimited"
+        }
+        if let balance = usage.balanceAmount {
+            return "\(currency(balance)) left"
+        }
+        if let remaining = usage.remainingAmount {
+            return "\(currency(remaining)) left"
+        }
+        if let used = usage.usedAmount {
+            return "\(currency(used)) used"
+        }
+        if let limit = usage.limitAmount {
+            return "\(currency(limit)) limit"
+        }
+        if let percent = usage.usedPercent {
+            let formatted = percent.formatted(
+                .number.precision(.fractionLength(0...1))
+            )
+            return "\(formatted)% used"
+        }
+        return "Available"
+    }
+
+    private func currency(_ amount: Double) -> String {
+        amount.formatted(
+            .currency(code: usage.currencyCode)
+                .precision(.fractionLength(2))
+        )
     }
 }
 

--- a/AIUsage/Views/SettingsView.swift
+++ b/AIUsage/Views/SettingsView.swift
@@ -1,0 +1,464 @@
+import AppKit
+import SwiftUI
+
+struct SettingsView: View {
+    @Bindable var store: UsageStore
+    @Bindable var preferences: AppPreferences
+    @Bindable var launchAtLogin: LaunchAtLoginController
+    @Bindable var updateController: UpdateController
+    var showDashboard: @MainActor () -> Void = {}
+
+    var body: some View {
+        GlassEffectContainer(spacing: 10) {
+            VStack(alignment: .leading, spacing: 16) {
+                header
+                providersSection
+                generalSection
+                footer
+            }
+        }
+        .padding(20)
+        .frame(width: MenuBarPanelRoute.settings.width, alignment: .top)
+        .onAppear {
+            store.setTrackedProviders(preferences.trackedProviderIDs)
+            store.setRefreshInterval(preferences.refreshInterval)
+            launchAtLogin.synchronize()
+        }
+        .onChange(of: preferences.refreshInterval) { _, interval in
+            store.setRefreshInterval(interval)
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Button(action: showDashboard) {
+                Label("Usage", systemImage: "chevron.left")
+            }
+            .buttonStyle(.glass)
+            .controlSize(.small)
+            .help("Back to usage")
+            .accessibilityHint("Shows the usage dashboard")
+
+            Text("Settings")
+                .font(.title3.weight(.semibold))
+
+            Spacer()
+        }
+    }
+
+    private var providersSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            sectionHeader(
+                title: "Providers",
+                systemImage: "switch.2",
+                detail: "Choose what to track and what appears in the menu bar."
+            )
+
+            providerRows
+                .padding(.horizontal, 12)
+                .padding(.vertical, 4)
+                .glassEffect(.regular, in: .rect(cornerRadius: 14))
+        }
+    }
+
+    @ViewBuilder
+    private var providerRows: some View {
+        let descriptors = ProviderCatalog.all
+        if descriptors.count > 2 {
+            ScrollView {
+                providerRowsContent(descriptors)
+            }
+            .frame(maxHeight: 260)
+        } else {
+            providerRowsContent(descriptors)
+        }
+    }
+
+    private func providerRowsContent(
+        _ descriptors: [ProviderDescriptor]
+    ) -> some View {
+        VStack(spacing: 0) {
+            ProviderSettingsHeader()
+
+            Divider()
+
+            ForEach(descriptors) { descriptor in
+                let availableItems = store.availableMenuBarItems(
+                    for: descriptor.id
+                )
+                ProviderSettingsRow(
+                    descriptor: descriptor,
+                    state: store.states[descriptor.id],
+                    isTracking: preferences.isTracking(descriptor.id),
+                    isVisible:
+                        store.states[descriptor.id]?.isToolInstalled != false &&
+                        preferences.isProviderShownInMenuBar(descriptor.id),
+                    selectedMetrics: Set(
+                        preferences.selectedMenuBarMetrics(
+                            for: descriptor.id
+                        )
+                    ),
+                    availableItems: availableItems,
+                    setTracking: { enabled in
+                        preferences.setTracking(
+                            enabled,
+                            for: descriptor.id
+                        )
+                        store.setTrackedProviders(
+                            preferences.trackedProviderIDs
+                        )
+                    },
+                    setVisible: { enabled in
+                        preferences.setMenuBarVisibility(
+                            enabled,
+                            for: descriptor.id,
+                            availableItems: availableItems
+                        )
+                    },
+                    setMetric: { item, enabled in
+                        preferences.setMenuBarMetric(
+                            enabled,
+                            item: item,
+                            availableItems: availableItems
+                        )
+                    }
+                )
+
+                if descriptor.id != descriptors.last?.id {
+                    Divider()
+                }
+            }
+        }
+    }
+
+    private var generalSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("General")
+                .font(.headline)
+
+            Grid(
+                alignment: .leading,
+                horizontalSpacing: 18,
+                verticalSpacing: 11
+            ) {
+                GridRow {
+                    Text("Numbers")
+                        .foregroundStyle(.secondary)
+
+                    Picker("Numbers", selection: $preferences.usageDisplayMode) {
+                        ForEach(UsageDisplayMode.allCases) { mode in
+                            Text(mode.title)
+                                .tag(mode)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    .frame(width: 130)
+                }
+
+                GridRow {
+                    Text("Refresh")
+                        .foregroundStyle(.secondary)
+
+                    Picker("Refresh", selection: $preferences.refreshInterval) {
+                        ForEach(RefreshIntervalOption.allCases) { option in
+                            Text(option.title)
+                                .tag(option)
+                        }
+                    }
+                    .labelsHidden()
+                    .frame(width: 180, alignment: .leading)
+                }
+
+                GridRow(alignment: .top) {
+                    Text("Startup")
+                        .foregroundStyle(.secondary)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Toggle(
+                            "Launch at Login",
+                            isOn: Binding(
+                                get: { launchAtLogin.isEnabled },
+                                set: { launchAtLogin.setEnabled($0) }
+                            )
+                        )
+                        .toggleStyle(.switch)
+                        .controlSize(.small)
+
+                        if launchAtLogin.requiresApproval {
+                            Text("Approval needed in System Settings")
+                                .font(.caption)
+                                .foregroundStyle(.orange)
+                        } else if let error = launchAtLogin.errorMessage {
+                            Text(error)
+                                .font(.caption)
+                                .foregroundStyle(.red)
+                        }
+                    }
+                }
+            }
+            .padding(.leading, 12)
+        }
+    }
+
+    private var footer: some View {
+        HStack(spacing: 12) {
+            Button("Check for Updates…") {
+                updateController.checkForUpdates()
+            }
+            .disabled(updateController.isChecking)
+
+            if updateController.isChecking {
+                ProgressView()
+                    .controlSize(.small)
+            }
+
+            Link("Star on GitHub", destination: AppLinks.repository)
+
+            Spacer()
+
+            Button("Quit AI Usage") {
+                NSApplication.shared.terminate(nil)
+            }
+        }
+        .controlSize(.small)
+        .padding(.top, 2)
+    }
+
+    private func sectionHeader(
+        title: String,
+        systemImage: String,
+        detail: String
+    ) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Label(title, systemImage: systemImage)
+                .font(.headline)
+            Text(detail)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+    }
+}
+
+private struct ProviderSettingsHeader: View {
+    var body: some View {
+        HStack(spacing: 10) {
+            Text("Provider")
+                .frame(width: 130, alignment: .leading)
+            Text("Track")
+                .frame(width: 44)
+            Label("Menu Bar", systemImage: "menubar.rectangle")
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 7)
+    }
+}
+
+private struct ProviderSettingsRow: View {
+    let descriptor: ProviderDescriptor
+    let state: ProviderState?
+    let isTracking: Bool
+    let isVisible: Bool
+    let selectedMetrics: Set<MenuBarMetricID>
+    let availableItems: [MenuBarItemID]
+    let setTracking: (Bool) -> Void
+    let setVisible: (Bool) -> Void
+    let setMetric: (MenuBarItemID, Bool) -> Void
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 10) {
+            HStack(spacing: 8) {
+                ProviderIcon(provider: descriptor.id, size: 22)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(descriptor.displayName)
+                        .font(.body.weight(.medium))
+
+                    if isTracking {
+                        ProviderStatusView(state: state)
+                    } else {
+                        Label("Off", systemImage: "pause.circle")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .frame(width: 130, alignment: .leading)
+
+            Toggle(
+                "Track \(descriptor.displayName)",
+                isOn: Binding(
+                    get: { isTracking },
+                    set: { enabled in setTracking(enabled) }
+                )
+            )
+            .labelsHidden()
+            .toggleStyle(.switch)
+            .controlSize(.small)
+            .frame(width: 44)
+            .accessibilityLabel("Track \(descriptor.displayName)")
+
+            HStack(spacing: 8) {
+                Toggle(
+                    "Show \(descriptor.displayName) in Menu Bar",
+                    isOn: Binding(
+                        get: { isVisible },
+                        set: { enabled in setVisible(enabled) }
+                    )
+                )
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .controlSize(.small)
+                .frame(width: 44)
+                .disabled(!isTracking || (!isVisible && !canEnableMenuBar))
+                .help(
+                    isVisible
+                        ? "Hide \(descriptor.displayName) from the menu bar"
+                        : "Show \(descriptor.displayName) in the menu bar"
+                )
+
+                Divider()
+                    .frame(height: 20)
+
+                menuBarMetrics
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.vertical, 9)
+        .accessibilityElement(children: .contain)
+    }
+
+    @ViewBuilder
+    private var menuBarMetrics: some View {
+        if availableItems.isEmpty {
+            Text(emptyMetricsMessage)
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        } else {
+            HStack(spacing: 8) {
+                ForEach(availableItems) { item in
+                    Toggle(
+                        item.metric.title,
+                        isOn: Binding(
+                            get: {
+                                selectedMetrics.contains(item.metric)
+                            },
+                            set: { enabled in
+                                setMetric(item, enabled)
+                            }
+                        )
+                    )
+                    .font(.caption)
+                    .toggleStyle(.checkbox)
+                    .controlSize(.small)
+                    .disabled(!isTracking || !isVisible)
+                    .help(
+                        enabledMetricHelp(
+                            item.metric,
+                            isSelected:
+                                selectedMetrics.contains(item.metric)
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    private var canEnableMenuBar: Bool {
+        state?.isToolInstalled != false &&
+            (!selectedMetrics.isEmpty || !availableItems.isEmpty)
+    }
+
+    private var emptyMetricsMessage: String {
+        if state?.isToolInstalled == false {
+            return "Not installed"
+        }
+        if state?.isRefreshing == true {
+            return "Loading available metrics…"
+        }
+        if state?.failure?.kind == .authentication {
+            return "Log in to choose metrics"
+        }
+        return "No usage metrics returned"
+    }
+
+    private func enabledMetricHelp(
+        _ metric: MenuBarMetricID,
+        isSelected: Bool
+    ) -> String {
+        isSelected
+            ? "Hide \(metric.title) for \(descriptor.displayName)"
+            : "Show \(metric.title) for \(descriptor.displayName)"
+    }
+}
+
+private struct ProviderStatusView: View {
+    let state: ProviderState?
+
+    var body: some View {
+        let presentation = ProviderStatusPresentation(state: state)
+
+        Label(presentation.text, systemImage: presentation.systemImage)
+            .font(.caption)
+            .foregroundStyle(presentation.color)
+            .labelStyle(.titleAndIcon)
+            .accessibilityLabel(presentation.text)
+    }
+}
+
+private struct ProviderStatusPresentation {
+    let text: String
+    let systemImage: String
+    let color: Color
+
+    init(state: ProviderState?) {
+        guard let state else {
+            text = "Checking…"
+            systemImage = "clock"
+            color = .secondary
+            return
+        }
+
+        if state.isToolInstalled == false {
+            text = "Not installed"
+            systemImage = "minus.circle"
+            color = .secondary
+            return
+        }
+
+        if let failure = state.failure {
+            switch failure.kind {
+            case .authentication:
+                text = "Not logged in"
+                systemImage = "person.crop.circle.badge.exclamationmark"
+                color = .orange
+            case .rateLimited:
+                text = "Rate limited"
+                systemImage = "hourglass"
+                color = .orange
+            case .transient, .invalidResponse, .storage:
+                text = state.snapshot == nil
+                    ? "Temporarily unavailable"
+                    : "Showing last update"
+                systemImage = "exclamationmark.triangle"
+                color = .orange
+            }
+            return
+        }
+
+        if state.snapshot != nil {
+            text = "Connected"
+            systemImage = "checkmark.circle.fill"
+            color = .green
+        } else {
+            text = state.isRefreshing ? "Checking…" : "Waiting for usage"
+            systemImage = "clock"
+            color = .secondary
+        }
+    }
+}

--- a/AIUsageTests/AppPreferencesTests.swift
+++ b/AIUsageTests/AppPreferencesTests.swift
@@ -32,14 +32,14 @@ final class AppPreferencesTests: XCTestCase {
 
     func testPreferencesPersistUsingExistingKeys() {
         let preferences = AppPreferences(defaults: defaults)
-        preferences.menuBarSelection = .codex
+        preferences.menuBarSelection = .all
         preferences.menuBarWindow = .weekly
         preferences.usageDisplayMode = .used
         preferences.refreshInterval = .thirtyMinutes
 
         let restored = AppPreferences(defaults: defaults)
 
-        XCTAssertEqual(restored.menuBarSelection, .codex)
+        XCTAssertEqual(restored.menuBarSelection, .all)
         XCTAssertEqual(restored.menuBarWindow, .weekly)
         XCTAssertEqual(restored.usageDisplayMode, .used)
         XCTAssertEqual(restored.refreshInterval, .thirtyMinutes)

--- a/AIUsageTests/AppPreferencesTests.swift
+++ b/AIUsageTests/AppPreferencesTests.swift
@@ -2,7 +2,6 @@ import Foundation
 import XCTest
 @testable import AIUsage
 
-@MainActor
 final class AppPreferencesTests: XCTestCase {
     private var defaults: UserDefaults!
     private var suiteName: String!
@@ -21,41 +20,465 @@ final class AppPreferencesTests: XCTestCase {
         super.tearDown()
     }
 
-    func testDefaultsMatchProductChoices() {
+    @MainActor
+    func testFreshInstallDefaultsMatchProductChoices() {
         let preferences = AppPreferences(defaults: defaults)
 
-        XCTAssertEqual(preferences.menuBarSelection, .automatic)
-        XCTAssertEqual(preferences.menuBarWindow, .session)
+        XCTAssertEqual(
+            preferences.trackedProviderIDs,
+            Set(ProviderID.allCases)
+        )
+        XCTAssertEqual(preferences.visibleMenuBarProviderIDs, [])
+        XCTAssertEqual(preferences.menuBarMetricSelections, [:])
+        XCTAssertFalse(preferences.hasConfiguredMenuBar)
+        XCTAssertFalse(preferences.hasCompletedInitialSetup)
         XCTAssertEqual(preferences.usageDisplayMode, .remaining)
         XCTAssertEqual(preferences.refreshInterval, .fiveMinutes)
     }
 
-    func testPreferencesPersistUsingExistingKeys() {
+    @MainActor
+    func testFreshConfigurationPrefersWeeklyPerProvider() {
         let preferences = AppPreferences(defaults: defaults)
-        preferences.menuBarSelection = .all
-        preferences.menuBarWindow = .weekly
+
+        preferences.configureDefaultMenuBarProviders(
+            availableItemsByProvider: availableItemsByProvider
+        )
+
+        XCTAssertEqual(
+            preferences.visibleMenuBarProviderIDs,
+            [.claude, .codex]
+        )
+        XCTAssertEqual(
+            preferences.selectedMenuBarMetrics(for: .claude),
+            [.weekly]
+        )
+        XCTAssertEqual(
+            preferences.selectedMenuBarMetrics(for: .codex),
+            [.weekly]
+        )
+        XCTAssertTrue(preferences.hasConfiguredMenuBar)
+    }
+
+    @MainActor
+    func testFreshConfigurationKeepsWeeklyWhenLiveDataOmitsIt() {
+        let preferences = AppPreferences(defaults: defaults)
+        let claudeItems = [
+            MenuBarItemID(provider: .claude, metric: .session),
+            MenuBarItemID(provider: .claude, metric: .fable)
+        ]
+
+        preferences.configureDefaultMenuBarProviders(
+            availableItemsByProvider: [.claude: claudeItems]
+        )
+
+        XCTAssertEqual(
+            preferences.visibleMenuBarProviderIDs,
+            [.claude, .codex]
+        )
+        XCTAssertEqual(
+            preferences.selectedMenuBarMetrics(for: .claude),
+            [.weekly]
+        )
+        XCTAssertEqual(
+            preferences.selectedMenuBarMetrics(for: .codex),
+            [.weekly]
+        )
+    }
+
+    @MainActor
+    func testFreshConfigurationKeepsWeeklyReadyWithNoToolsInstalled() {
+        let preferences = AppPreferences(defaults: defaults)
+
+        preferences.configureDefaultMenuBarProviders(
+            availableItemsByProvider: [:]
+        )
+
+        XCTAssertEqual(
+            preferences.visibleMenuBarProviderIDs,
+            [.claude, .codex]
+        )
+        XCTAssertEqual(
+            preferences.selectedMenuBarMetrics(for: .claude),
+            [.weekly]
+        )
+        XCTAssertEqual(
+            preferences.selectedMenuBarMetrics(for: .codex),
+            [.weekly]
+        )
+    }
+
+    @MainActor
+    func testProviderAndMetricSelectionsPersist() {
+        let preferences = AppPreferences(defaults: defaults)
+        let claudeItems = availableItemsByProvider[.claude]!
+
+        preferences.setMenuBarMetric(
+            true,
+            item: claudeItems[1],
+            availableItems: claudeItems
+        )
+        preferences.setMenuBarVisibility(
+            true,
+            for: .claude,
+            availableItems: claudeItems
+        )
         preferences.usageDisplayMode = .used
         preferences.refreshInterval = .thirtyMinutes
+        preferences.markInitialSetupCompleted()
 
         let restored = AppPreferences(defaults: defaults)
 
-        XCTAssertEqual(restored.menuBarSelection, .all)
-        XCTAssertEqual(restored.menuBarWindow, .weekly)
+        XCTAssertEqual(restored.visibleMenuBarProviderIDs, [.claude])
+        XCTAssertEqual(
+            restored.selectedMenuBarMetrics(for: .claude),
+            [.weekly]
+        )
         XCTAssertEqual(restored.usageDisplayMode, .used)
         XCTAssertEqual(restored.refreshInterval, .thirtyMinutes)
+        XCTAssertTrue(restored.hasCompletedInitialSetup)
     }
 
-    func testInvalidStoredValuesFallBackSafely() {
+    @MainActor
+    func testEnablingProviderWithNoSelectionChoosesFirstLiveMetric() {
+        let preferences = AppPreferences(defaults: defaults)
+        let codexItems = availableItemsByProvider[.codex]!
+
+        preferences.setMenuBarVisibility(
+            true,
+            for: .codex,
+            availableItems: codexItems
+        )
+
+        XCTAssertTrue(preferences.isProviderShownInMenuBar(.codex))
+        XCTAssertEqual(
+            preferences.selectedMenuBarMetrics(for: .codex),
+            [.weekly]
+        )
+    }
+
+    @MainActor
+    func testTurningOffProviderPreservesMetricSelections() {
+        let preferences = AppPreferences(defaults: defaults)
+        let claudeItems = availableItemsByProvider[.claude]!
+
+        preferences.setMenuBarVisibility(
+            true,
+            for: .claude,
+            availableItems: claudeItems
+        )
+        preferences.setMenuBarMetric(
+            true,
+            item: claudeItems[0],
+            availableItems: claudeItems
+        )
+        preferences.setMenuBarVisibility(
+            false,
+            for: .claude,
+            availableItems: claudeItems
+        )
+
+        XCTAssertFalse(preferences.isProviderShownInMenuBar(.claude))
+        XCTAssertEqual(
+            preferences.selectedMenuBarMetrics(for: .claude),
+            [.session, .weekly]
+        )
+    }
+
+    @MainActor
+    func testTurningOffLastMetricHidesProviderButKeepsTracking() {
+        let preferences = AppPreferences(defaults: defaults)
+        let claudeItems = availableItemsByProvider[.claude]!
+        let weekly = claudeItems[1]
+
+        preferences.setMenuBarVisibility(
+            true,
+            for: .claude,
+            availableItems: claudeItems
+        )
+        preferences.setMenuBarMetric(
+            false,
+            item: weekly,
+            availableItems: claudeItems
+        )
+
+        XCTAssertFalse(preferences.isProviderShownInMenuBar(.claude))
+        XCTAssertEqual(
+            preferences.selectedMenuBarMetrics(for: .claude),
+            []
+        )
+        XCTAssertTrue(preferences.isTracking(.claude))
+
+        preferences.setMenuBarMetric(
+            true,
+            item: weekly,
+            availableItems: claudeItems
+        )
+
+        XCTAssertTrue(preferences.isProviderShownInMenuBar(.claude))
+        XCTAssertEqual(
+            preferences.selectedMenuBarMetrics(for: .claude),
+            [.weekly]
+        )
+    }
+
+    @MainActor
+    func testSelectingMetricShowsHiddenProviderAgain() {
+        let preferences = AppPreferences(defaults: defaults)
+        let codexItems = availableItemsByProvider[.codex]!
+
+        preferences.setMenuBarMetric(
+            true,
+            item: codexItems[1],
+            availableItems: codexItems
+        )
+
+        XCTAssertTrue(preferences.isProviderShownInMenuBar(.codex))
+        XCTAssertEqual(
+            preferences.selectedMenuBarMetrics(for: .codex),
+            [.spark]
+        )
+    }
+
+    @MainActor
+    func testMetricSelectionsUseProviderLiveOrder() {
+        let preferences = AppPreferences(defaults: defaults)
+        let codexItems = availableItemsByProvider[.codex]!
+
+        preferences.setMenuBarMetric(
+            true,
+            item: codexItems[2],
+            availableItems: codexItems
+        )
+        preferences.setMenuBarMetric(
+            true,
+            item: codexItems[0],
+            availableItems: codexItems
+        )
+        preferences.setMenuBarMetric(
+            true,
+            item: codexItems[1],
+            availableItems: codexItems
+        )
+
+        XCTAssertEqual(
+            preferences.selectedMenuBarMetrics(for: .codex),
+            [.weekly, .spark, .credits]
+        )
+    }
+
+    @MainActor
+    func testTurningOffTrackingHidesProviderButPreservesMetrics() {
+        let preferences = AppPreferences(defaults: defaults)
+        let claudeItems = availableItemsByProvider[.claude]!
+
+        preferences.setMenuBarVisibility(
+            true,
+            for: .claude,
+            availableItems: claudeItems
+        )
+        preferences.setTracking(false, for: .claude)
+
+        XCTAssertFalse(preferences.isProviderShownInMenuBar(.claude))
+        XCTAssertEqual(
+            preferences.selectedMenuBarMetrics(for: .claude),
+            [.weekly]
+        )
+        XCTAssertFalse(preferences.isTracking(.claude))
+    }
+
+    @MainActor
+    func testV2ItemsMigrateIntoProviderGroupsUsingLiveOrder() throws {
+        let oldItems = [
+            MenuBarItemID(provider: .codex, metric: .spark),
+            MenuBarItemID(provider: .claude, metric: .weekly),
+            MenuBarItemID(provider: .claude, metric: .session)
+        ]
+        defaults.set(
+            try JSONEncoder().encode(oldItems),
+            forKey: "menuBarItems.v2"
+        )
+        defaults.set(true, forKey: "menuBarItemsConfigured.v2")
+
+        let preferences = AppPreferences(defaults: defaults)
+        XCTAssertFalse(preferences.hasConfiguredMenuBar)
+
+        preferences.configureDefaultMenuBarProviders(
+            availableItemsByProvider: availableItemsByProvider
+        )
+
+        XCTAssertEqual(
+            preferences.visibleMenuBarProviderIDs,
+            [.claude, .codex]
+        )
+        XCTAssertEqual(
+            preferences.selectedMenuBarMetrics(for: .claude),
+            [.session, .weekly]
+        )
+        XCTAssertEqual(
+            preferences.selectedMenuBarMetrics(for: .codex),
+            [.spark]
+        )
+        XCTAssertEqual(
+            preferences.menuBarProviderConfigurations.map(\.provider),
+            [.claude, .codex]
+        )
+    }
+
+    @MainActor
+    func testUnavailableV2MetricFallsBackToFirstLiveMetric() throws {
+        let oldItems = [
+            MenuBarItemID(provider: .codex, metric: .session)
+        ]
+        defaults.set(
+            try JSONEncoder().encode(oldItems),
+            forKey: "menuBarItems.v2"
+        )
+        defaults.set(true, forKey: "menuBarItemsConfigured.v2")
+
+        let preferences = AppPreferences(defaults: defaults)
+        preferences.configureDefaultMenuBarProviders(
+            availableItemsByProvider: availableItemsByProvider
+        )
+
+        XCTAssertEqual(
+            preferences.selectedMenuBarMetrics(for: .codex),
+            [.weekly]
+        )
+        XCTAssertTrue(preferences.isProviderShownInMenuBar(.codex))
+    }
+
+    @MainActor
+    func testV2SelectionSurvivesMigrationWhileToolIsNotInstalled() throws {
+        let oldItems = [
+            MenuBarItemID(provider: .codex, metric: .credits)
+        ]
+        defaults.set(
+            try JSONEncoder().encode(oldItems),
+            forKey: "menuBarItems.v2"
+        )
+        defaults.set(true, forKey: "menuBarItemsConfigured.v2")
+
+        let preferences = AppPreferences(defaults: defaults)
+        preferences.configureDefaultMenuBarProviders(
+            availableItemsByProvider: [
+                .claude: availableItemsByProvider[.claude]!
+            ]
+        )
+
+        XCTAssertEqual(
+            preferences.selectedMenuBarMetrics(for: .codex),
+            [.credits]
+        )
+        XCTAssertTrue(preferences.isProviderShownInMenuBar(.codex))
+    }
+
+    @MainActor
+    func testLegacyReleaseCanSkipVersionsAndStillGetsWeeklyForBoth() {
+        defaults.set("codex", forKey: "menuBarSelection")
+        defaults.set("session", forKey: "menuBarWindow")
+
+        let preferences = AppPreferences(defaults: defaults)
+        preferences.configureDefaultMenuBarProviders(
+            availableItemsByProvider: [:]
+        )
+
+        XCTAssertEqual(
+            preferences.visibleMenuBarProviderIDs,
+            [.claude, .codex]
+        )
+        XCTAssertEqual(
+            preferences.selectedMenuBarMetrics(for: .claude),
+            [.weekly]
+        )
+        XCTAssertEqual(
+            preferences.selectedMenuBarMetrics(for: .codex),
+            [.weekly]
+        )
+    }
+
+    @MainActor
+    func testLaterUpdatesPreserveTheUsersExactMenuBarChoices() {
+        let firstRun = AppPreferences(defaults: defaults)
+        firstRun.configureDefaultMenuBarProviders(
+            availableItemsByProvider: availableItemsByProvider
+        )
+
+        let claudeItems = availableItemsByProvider[.claude]!
+        let codexItems = availableItemsByProvider[.codex]!
+        firstRun.setMenuBarMetric(
+            true,
+            item: claudeItems[0],
+            availableItems: claudeItems
+        )
+        firstRun.setMenuBarMetric(
+            false,
+            item: claudeItems[1],
+            availableItems: claudeItems
+        )
+        firstRun.setMenuBarMetric(
+            false,
+            item: codexItems[0],
+            availableItems: codexItems
+        )
+
+        for _ in 0..<2 {
+            let afterUpdate = AppPreferences(defaults: defaults)
+            afterUpdate.configureDefaultMenuBarProviders(
+                availableItemsByProvider: [:]
+            )
+
+            XCTAssertEqual(
+                afterUpdate.visibleMenuBarProviderIDs,
+                [.claude]
+            )
+            XCTAssertEqual(
+                afterUpdate.selectedMenuBarMetrics(for: .claude),
+                [.session]
+            )
+            XCTAssertEqual(
+                afterUpdate.selectedMenuBarMetrics(for: .codex),
+                []
+            )
+        }
+    }
+
+    @MainActor
+    func testInvalidStoredScalarValuesFallBackSafely() {
         defaults.set("unknown", forKey: "menuBarSelection")
         defaults.set("unknown", forKey: "menuBarWindow")
         defaults.set("unknown", forKey: "usageDisplayMode")
         defaults.set("unknown", forKey: "refreshInterval")
 
         let preferences = AppPreferences(defaults: defaults)
+        preferences.configureDefaultMenuBarProviders(
+            availableItemsByProvider: availableItemsByProvider
+        )
 
-        XCTAssertEqual(preferences.menuBarSelection, .automatic)
-        XCTAssertEqual(preferences.menuBarWindow, .session)
         XCTAssertEqual(preferences.usageDisplayMode, .remaining)
         XCTAssertEqual(preferences.refreshInterval, .fiveMinutes)
+        XCTAssertEqual(
+            preferences.selectedMenuBarMetrics(for: .claude),
+            [.weekly]
+        )
+        XCTAssertEqual(
+            preferences.selectedMenuBarMetrics(for: .codex),
+            [.weekly]
+        )
+    }
+
+    private var availableItemsByProvider:
+        [ProviderID: [MenuBarItemID]] {
+        [
+            .claude: [
+                MenuBarItemID(provider: .claude, metric: .session),
+                MenuBarItemID(provider: .claude, metric: .weekly),
+                MenuBarItemID(provider: .claude, metric: .fable)
+            ],
+            .codex: [
+                MenuBarItemID(provider: .codex, metric: .weekly),
+                MenuBarItemID(provider: .codex, metric: .spark),
+                MenuBarItemID(provider: .codex, metric: .credits)
+            ]
+        ]
     }
 }

--- a/AIUsageTests/MapperTests.swift
+++ b/AIUsageTests/MapperTests.swift
@@ -17,7 +17,13 @@ final class MapperTests: XCTestCase {
               "resets_at": "2027-01-20T00:00:00Z"
             }
           ],
-          "extra_usage": {"is_enabled": true, "used_credits": 9999}
+          "extra_usage": {
+            "is_enabled": true,
+            "used_credits": 9999,
+            "monthly_limit": 20000,
+            "utilization": 49.995,
+            "currency": "USD"
+          }
         }
         """)
         let oauth = ClaudeOAuth(
@@ -38,6 +44,14 @@ final class MapperTests: XCTestCase {
         XCTAssertEqual(snapshot.planName, "Pro Plan 20x")
         XCTAssertEqual(snapshot.windows.map(\.kind), [.session, .weekly, .sonnet, .fable])
         XCTAssertEqual(snapshot.windows.map(\.usedPercent), [12.5, 44, 67, 89])
+        XCTAssertEqual(snapshot.creditUsage?.usedAmount, 99.99)
+        XCTAssertEqual(snapshot.creditUsage?.limitAmount, 200)
+        XCTAssertEqual(
+            snapshot.creditUsage?.remainingAmount ?? -1,
+            100.01,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(snapshot.creditUsage?.currencyCode, "USD")
         XCTAssertNotNil(snapshot.windows[0].resetsAt)
         XCTAssertEqual(
             snapshot.windows[1].resetsAt,
@@ -54,6 +68,11 @@ final class MapperTests: XCTestCase {
         let response = httpResponse(json: """
         {
           "plan_type": "prolite",
+          "credits": {
+            "has_credits": true,
+            "unlimited": false,
+            "balance": "42.50"
+          },
           "rate_limit": {
             "primary_window": {
               "used_percent": 73,
@@ -84,6 +103,9 @@ final class MapperTests: XCTestCase {
 
         XCTAssertEqual(snapshot.planName, "Pro 5x")
         XCTAssertEqual(snapshot.windows.map(\.kind), [.weekly, .sparkSession, .sparkWeekly])
+        XCTAssertEqual(snapshot.creditUsage?.balanceAmount, 42.5)
+        XCTAssertEqual(snapshot.creditUsage?.currencyCode, "USD")
+        XCTAssertFalse(snapshot.creditUsage?.isUnlimited == true)
         XCTAssertEqual(snapshot.windows[0].usedPercent, 73)
         XCTAssertEqual(snapshot.windows[1].usedPercent, 101.4)
         XCTAssertEqual(snapshot.windows[1].renderedFraction, 1)
@@ -112,6 +134,69 @@ final class MapperTests: XCTestCase {
         let snapshot = try CodexUsageMapper.map(response: response, now: Date())
 
         XCTAssertEqual(snapshot.windows.map(\.usedPercent), [17.25, 68])
+    }
+
+    func testCodexMapsUnlimitedCreditsWithoutBalance() throws {
+        let response = httpResponse(json: """
+        {
+          "credits": {
+            "has_credits": true,
+            "unlimited": true,
+            "balance": null
+          }
+        }
+        """)
+
+        let snapshot = try CodexUsageMapper.map(response: response, now: Date())
+
+        XCTAssertTrue(snapshot.creditUsage?.isUnlimited == true)
+        XCTAssertNil(snapshot.creditUsage?.balanceAmount)
+    }
+
+    func testCodexKeepsCreditAvailabilityWithoutBalance() throws {
+        let response = httpResponse(json: """
+        {
+          "credits": {
+            "has_credits": true,
+            "unlimited": false,
+            "balance": null
+          }
+        }
+        """)
+
+        let snapshot = try CodexUsageMapper.map(response: response, now: Date())
+
+        XCTAssertNotNil(snapshot.creditUsage)
+        XCTAssertNil(snapshot.creditUsage?.balanceAmount)
+        XCTAssertFalse(snapshot.creditUsage?.isUnlimited == true)
+    }
+
+    func testClaudeOmitsDisabledExtraUsage() throws {
+        let response = httpResponse(json: """
+        {
+          "extra_usage": {
+            "is_enabled": false,
+            "used_credits": 9999,
+            "monthly_limit": 20000
+          }
+        }
+        """)
+        let oauth = ClaudeOAuth(
+            accessToken: "token",
+            refreshToken: nil,
+            expiresAt: nil,
+            subscriptionType: "pro",
+            rateLimitTier: nil,
+            scopes: ["user:profile"]
+        )
+
+        let snapshot = try ClaudeUsageMapper.map(
+            response: response,
+            credentials: oauth,
+            now: Date()
+        )
+
+        XCTAssertNil(snapshot.creditUsage)
     }
 
     func testParsingRejectsBooleanAsNumberAndEscapesFormValues() {

--- a/AIUsageTests/MapperTests.swift
+++ b/AIUsageTests/MapperTests.swift
@@ -17,13 +17,7 @@ final class MapperTests: XCTestCase {
               "resets_at": "2027-01-20T00:00:00Z"
             }
           ],
-          "extra_usage": {
-            "is_enabled": true,
-            "used_credits": 9999,
-            "monthly_limit": 20000,
-            "utilization": 49.995,
-            "currency": "USD"
-          }
+          "extra_usage": {"is_enabled": true, "used_credits": 9999}
         }
         """)
         let oauth = ClaudeOAuth(
@@ -44,14 +38,6 @@ final class MapperTests: XCTestCase {
         XCTAssertEqual(snapshot.planName, "Pro Plan 20x")
         XCTAssertEqual(snapshot.windows.map(\.kind), [.session, .weekly, .sonnet, .fable])
         XCTAssertEqual(snapshot.windows.map(\.usedPercent), [12.5, 44, 67, 89])
-        XCTAssertEqual(snapshot.creditUsage?.usedAmount, 99.99)
-        XCTAssertEqual(snapshot.creditUsage?.limitAmount, 200)
-        XCTAssertEqual(
-            snapshot.creditUsage?.remainingAmount ?? -1,
-            100.01,
-            accuracy: 0.001
-        )
-        XCTAssertEqual(snapshot.creditUsage?.currencyCode, "USD")
         XCTAssertNotNil(snapshot.windows[0].resetsAt)
         XCTAssertEqual(
             snapshot.windows[1].resetsAt,
@@ -68,11 +54,6 @@ final class MapperTests: XCTestCase {
         let response = httpResponse(json: """
         {
           "plan_type": "prolite",
-          "credits": {
-            "has_credits": true,
-            "unlimited": false,
-            "balance": "42.50"
-          },
           "rate_limit": {
             "primary_window": {
               "used_percent": 73,
@@ -103,9 +84,6 @@ final class MapperTests: XCTestCase {
 
         XCTAssertEqual(snapshot.planName, "Pro 5x")
         XCTAssertEqual(snapshot.windows.map(\.kind), [.weekly, .sparkSession, .sparkWeekly])
-        XCTAssertEqual(snapshot.creditUsage?.balanceAmount, 42.5)
-        XCTAssertEqual(snapshot.creditUsage?.currencyCode, "USD")
-        XCTAssertFalse(snapshot.creditUsage?.isUnlimited == true)
         XCTAssertEqual(snapshot.windows[0].usedPercent, 73)
         XCTAssertEqual(snapshot.windows[1].usedPercent, 101.4)
         XCTAssertEqual(snapshot.windows[1].renderedFraction, 1)
@@ -136,67 +114,169 @@ final class MapperTests: XCTestCase {
         XCTAssertEqual(snapshot.windows.map(\.usedPercent), [17.25, 68])
     }
 
-    func testCodexMapsUnlimitedCreditsWithoutBalance() throws {
-        let response = httpResponse(json: """
-        {
-          "credits": {
-            "has_credits": true,
-            "unlimited": true,
-            "balance": null
-          }
-        }
-        """)
-
-        let snapshot = try CodexUsageMapper.map(response: response, now: Date())
-
-        XCTAssertTrue(snapshot.creditUsage?.isUnlimited == true)
-        XCTAssertNil(snapshot.creditUsage?.balanceAmount)
-    }
-
-    func testCodexKeepsCreditAvailabilityWithoutBalance() throws {
-        let response = httpResponse(json: """
-        {
-          "credits": {
-            "has_credits": true,
-            "unlimited": false,
-            "balance": null
-          }
-        }
-        """)
-
-        let snapshot = try CodexUsageMapper.map(response: response, now: Date())
-
-        XCTAssertNotNil(snapshot.creditUsage)
-        XCTAssertNil(snapshot.creditUsage?.balanceAmount)
-        XCTAssertFalse(snapshot.creditUsage?.isUnlimited == true)
-    }
-
-    func testClaudeOmitsDisabledExtraUsage() throws {
+    func testClaudeMapsBoundedExtraUsageFromCents() throws {
         let response = httpResponse(json: """
         {
           "extra_usage": {
-            "is_enabled": false,
-            "used_credits": 9999,
-            "monthly_limit": 20000
+            "is_enabled": true,
+            "used_credits": 500,
+            "monthly_limit": 1000
           }
         }
         """)
-        let oauth = ClaudeOAuth(
-            accessToken: "token",
-            refreshToken: nil,
-            expiresAt: nil,
-            subscriptionType: "pro",
-            rateLimitTier: nil,
-            scopes: ["user:profile"]
-        )
 
         let snapshot = try ClaudeUsageMapper.map(
             response: response,
-            credentials: oauth,
+            credentials: claudeOAuth(),
             now: Date()
         )
 
-        XCTAssertNil(snapshot.creditUsage)
+        XCTAssertEqual(
+            snapshot.billingUsage,
+            .boundedSpend(
+                usedAmount: 5,
+                limitAmount: 10,
+                currencyCode: "USD"
+            )
+        )
+    }
+
+    func testClaudeMapsUncappedExtraUsageAsSpend() throws {
+        let response = httpResponse(json: """
+        {
+          "extra_usage": {
+            "is_enabled": true,
+            "used_credits": 123456,
+            "monthly_limit": 0
+          }
+        }
+        """)
+
+        let snapshot = try ClaudeUsageMapper.map(
+            response: response,
+            credentials: claudeOAuth(),
+            now: Date()
+        )
+
+        XCTAssertEqual(
+            snapshot.billingUsage,
+            .unboundedSpend(
+                usedAmount: 1234.56,
+                currencyCode: "USD"
+            )
+        )
+    }
+
+    func testClaudeOmitsDisabledOrEmptyUncappedExtraUsage() throws {
+        for json in [
+            """
+            {"extra_usage":{"is_enabled":false,"used_credits":500}}
+            """,
+            """
+            {"extra_usage":{"is_enabled":true,"used_credits":0}}
+            """,
+            """
+            {"extra_usage":{"is_enabled":true,"used_credits":0,"monthly_limit":0}}
+            """
+        ] {
+            let snapshot = try ClaudeUsageMapper.map(
+                response: httpResponse(json: json),
+                credentials: claudeOAuth(),
+                now: Date()
+            )
+
+            XCTAssertNil(snapshot.billingUsage)
+        }
+    }
+
+    func testCodexFloorsCreditCountAndPricesEachCreditAtFourCents() throws {
+        let snapshot = try CodexUsageMapper.map(
+            response: httpResponse(json: """
+            {"credits":{"balance":"820.9"}}
+            """),
+            now: Date()
+        )
+
+        XCTAssertEqual(
+            snapshot.billingUsage,
+            .flexCreditBalance(
+                remainingCredits: 820,
+                usdValue: 32.8
+            )
+        )
+    }
+
+    func testCodexCreditBalanceUsesBodyThenHeaderFallback() throws {
+        let bodyWins = try CodexUsageMapper.map(
+            response: httpResponse(
+                json: """
+                {"credits":{"balance":"100"}}
+                """,
+                headers: ["x-codex-credits-balance": "25"]
+            ),
+            now: Date()
+        )
+        let headerFallback = try CodexUsageMapper.map(
+            response: httpResponse(
+                json: "{}",
+                headers: ["X-Codex-Credits-Balance": "42.9"]
+            ),
+            now: Date()
+        )
+
+        XCTAssertEqual(
+            bodyWins.billingUsage,
+            .flexCreditBalance(
+                remainingCredits: 100,
+                usdValue: 4
+            )
+        )
+        XCTAssertEqual(
+            headerFallback.billingUsage,
+            .flexCreditBalance(
+                remainingCredits: 42,
+                usdValue: 1.68
+            )
+        )
+    }
+
+    func testCodexTreatsNoCreditsAndNegativeBalanceAsRealZero() throws {
+        let responses = [
+            httpResponse(
+                json: """
+                {"credits":{"has_credits":false}}
+                """,
+                headers: ["x-codex-credits-balance": "25"]
+            ),
+            httpResponse(json: """
+            {"credits":{"balance":-5}}
+            """)
+        ]
+        for response in responses {
+            let snapshot = try CodexUsageMapper.map(
+                response: response,
+                now: Date()
+            )
+
+            XCTAssertEqual(
+                snapshot.billingUsage,
+                .flexCreditBalance(
+                    remainingCredits: 0,
+                    usdValue: 0
+                )
+            )
+        }
+    }
+
+    func testCodexOmitsUnknownCreditAvailability() throws {
+        let snapshot = try CodexUsageMapper.map(
+            response: httpResponse(json: """
+            {"credits":{"has_credits":true,"balance":null}}
+            """),
+            now: Date()
+        )
+
+        XCTAssertNil(snapshot.billingUsage)
     }
 
     func testParsingRejectsBooleanAsNumberAndEscapesFormValues() {
@@ -212,5 +292,16 @@ final class MapperTests: XCTestCase {
         XCTAssertNotNil(ProviderParsing.date("2027-01-15T12:00:00.123456"))
         XCTAssertNotNil(ProviderParsing.date("2027-01-15 12:00:00 UTC"))
         XCTAssertNotNil(ProviderParsing.date("2027-01-15T12:00:00+03:00"))
+    }
+
+    private func claudeOAuth() -> ClaudeOAuth {
+        ClaudeOAuth(
+            accessToken: "token",
+            refreshToken: nil,
+            expiresAt: nil,
+            subscriptionType: "pro",
+            rateLimitTier: nil,
+            scopes: ["user:profile"]
+        )
     }
 }

--- a/AIUsageTests/MenuBarControllerTests.swift
+++ b/AIUsageTests/MenuBarControllerTests.swift
@@ -19,4 +19,14 @@ final class MenuBarControllerTests: XCTestCase {
 
         XCTAssertFalse(gate.consumeSuppression())
     }
+
+    func testSettingsRouteExpandsTheSameCompactMenuBarPanel() {
+        XCTAssertEqual(MenuBarPanelRoute.dashboard.width, 392)
+        XCTAssertEqual(MenuBarPanelRoute.settings.width, 560)
+        XCTAssertGreaterThan(
+            MenuBarPanelRoute.settings.width,
+            MenuBarPanelRoute.dashboard.width
+        )
+        XCTAssertLessThan(MenuBarPanelRoute.settings.width, 600)
+    }
 }

--- a/AIUsageTests/MenuBarPresentationTests.swift
+++ b/AIUsageTests/MenuBarPresentationTests.swift
@@ -6,43 +6,42 @@ final class MenuBarPresentationTests: XCTestCase {
     func testPercentageStaysCompactAndMeaningRemainsAccessible() {
         let presentation = MenuBarPresentation(reading: MenuBarReading(
             provider: .codex,
-            percent: 62.4,
+            metric: .weekly,
+            value: .percentage(62.4),
             displayMode: .remaining,
-            isStale: true,
-            showsPlaceholder: false
+            isStale: true
         ))
 
         XCTAssertEqual(presentation.valueText, "62%")
         XCTAssertEqual(
             presentation.accessibilityLabel,
-            "Codex 62 percent left, stale"
+            "Codex Weekly 62 percent left, stale"
         )
         XCTAssertTrue(presentation.showsStaleIndicator)
     }
 
-    func testPinnedProviderWithoutUsageShowsPlaceholder() {
+    func testCreditsStayCompactAndExplainTheBalanceAccessibly() {
         let presentation = MenuBarPresentation(reading: MenuBarReading(
-            provider: .claude,
-            percent: nil,
-            displayMode: .used,
-            isStale: false,
-            showsPlaceholder: true
+            provider: .codex,
+            metric: .credits,
+            value: .credits(remaining: 120, usdValue: 4.8),
+            displayMode: .remaining,
+            isStale: false
         ))
 
-        XCTAssertEqual(presentation.valueText, "--")
-        XCTAssertEqual(presentation.accessibilityLabel, "Claude Code")
+        XCTAssertNotNil(presentation.valueText)
+        XCTAssertTrue(
+            presentation.accessibilityLabel.contains("120 credits left")
+        )
+        XCTAssertTrue(
+            presentation.accessibilityLabel.contains("worth")
+        )
     }
 
-    func testAutomaticSelectionWithoutUsageShowsOnlyGauge() {
-        let presentation = MenuBarPresentation(reading: MenuBarReading(
-            provider: nil,
-            percent: nil,
-            displayMode: .remaining,
-            isStale: false,
-            showsPlaceholder: false
-        ))
+    func testNoAvailableReadingsUsesOnlyTheAppIdentity() {
+        let presentation = MenuBarReadingsPresentation(readings: [])
 
-        XCTAssertNil(presentation.valueText)
+        XCTAssertEqual(presentation.items, [])
         XCTAssertEqual(presentation.accessibilityLabel, "AI usage")
     }
 
@@ -50,53 +49,256 @@ final class MenuBarPresentationTests: XCTestCase {
         let presentation = MenuBarReadingsPresentation(readings: [
             MenuBarReading(
                 provider: .claude,
-                percent: 62,
+                metric: .session,
+                value: .percentage(62),
                 displayMode: .used,
-                isStale: false,
-                showsPlaceholder: false
+                isStale: false
             ),
             MenuBarReading(
                 provider: .codex,
-                percent: 28,
+                metric: .sparkWeekly,
+                value: .percentage(28),
                 displayMode: .used,
-                isStale: true,
-                showsPlaceholder: false
+                isStale: true
             )
         ])
 
         XCTAssertEqual(presentation.items.map(\.valueText), ["62%", "28%"])
         XCTAssertEqual(
             presentation.accessibilityLabel,
-            "Claude Code 62 percent used, Codex 28 percent used, stale"
+            "Claude Code Session 62 percent used, Codex Spark Weekly 28 percent used, stale"
+        )
+    }
+
+    func testSingleSelectedMetricShowsOnlyItsValue() {
+        let group = MenuBarProviderReadings(
+            provider: .claude,
+            selectedMetrics: [.weekly],
+            readings: [
+                MenuBarReading(
+                    provider: .claude,
+                    metric: .weekly,
+                    value: .percentage(42),
+                    displayMode: .remaining,
+                    isStale: false
+                )
+            ]
+        )
+
+        let presentation = MenuBarProviderPresentation(group: group)
+
+        XCTAssertEqual(
+            presentation.metrics,
+            [
+                MenuBarMetricPresentation(
+                    label: nil,
+                    valueText: "42%",
+                    showsStaleIndicator: false
+                )
+            ]
+        )
+        XCTAssertNil(presentation.sharedSuffix)
+    }
+
+    func testMultipleSelectedMetricsUseMicroLabelsAndSharedPercent() {
+        let group = MenuBarProviderReadings(
+            provider: .claude,
+            selectedMetrics: [.session, .weekly],
+            readings: [
+                MenuBarReading(
+                    provider: .claude,
+                    metric: .session,
+                    value: .percentage(78),
+                    displayMode: .remaining,
+                    isStale: false
+                ),
+                MenuBarReading(
+                    provider: .claude,
+                    metric: .weekly,
+                    value: .percentage(42),
+                    displayMode: .remaining,
+                    isStale: false
+                )
+            ]
+        )
+
+        let presentation = MenuBarProviderPresentation(group: group)
+
+        XCTAssertEqual(
+            presentation.metrics,
+            [
+                MenuBarMetricPresentation(
+                    label: "S",
+                    valueText: "78",
+                    showsStaleIndicator: false
+                ),
+                MenuBarMetricPresentation(
+                    label: "W",
+                    valueText: "42",
+                    showsStaleIndicator: false
+                )
+            ]
+        )
+        XCTAssertEqual(presentation.sharedSuffix, "%")
+    }
+
+    func testMultipleSelectionsKeepLabelWhenOneReadingIsUnavailable() {
+        let group = MenuBarProviderReadings(
+            provider: .codex,
+            selectedMetrics: [.weekly, .spark],
+            readings: [
+                MenuBarReading(
+                    provider: .codex,
+                    metric: .spark,
+                    value: .percentage(28),
+                    displayMode: .used,
+                    isStale: false
+                )
+            ]
+        )
+
+        let presentation = MenuBarProviderPresentation(group: group)
+
+        XCTAssertEqual(
+            presentation.metrics,
+            [
+                MenuBarMetricPresentation(
+                    label: "Sp",
+                    valueText: "28",
+                    showsStaleIndicator: false
+                )
+            ]
+        )
+        XCTAssertEqual(presentation.sharedSuffix, "%")
+    }
+
+    func testMixedMetricTypesKeepTheirOwnUnits() {
+        let group = MenuBarProviderReadings(
+            provider: .codex,
+            selectedMetrics: [.weekly, .credits],
+            readings: [
+                MenuBarReading(
+                    provider: .codex,
+                    metric: .weekly,
+                    value: .percentage(42),
+                    displayMode: .remaining,
+                    isStale: false
+                ),
+                MenuBarReading(
+                    provider: .codex,
+                    metric: .credits,
+                    value: .credits(remaining: 120, usdValue: 4.8),
+                    displayMode: .remaining,
+                    isStale: false
+                )
+            ]
+        )
+
+        let presentation = MenuBarProviderPresentation(group: group)
+
+        XCTAssertEqual(presentation.metrics[0].label, "W")
+        XCTAssertEqual(presentation.metrics[0].valueText, "42%")
+        XCTAssertEqual(presentation.metrics[1].label, "C")
+        XCTAssertFalse(presentation.metrics[1].valueText.isEmpty)
+        XCTAssertNil(presentation.sharedSuffix)
+    }
+
+    func testProviderWithoutReadingsRemainsAccessibleWithoutPlaceholderText() {
+        let groups = [
+            MenuBarProviderReadings(
+                provider: .claude,
+                selectedMetrics: [.session],
+                readings: []
+            )
+        ]
+        let presentation = MenuBarReadingsPresentation(groups: groups)
+
+        XCTAssertEqual(presentation.items, [])
+        XCTAssertEqual(
+            presentation.accessibilityLabel,
+            "Claude Code, no usage data"
+        )
+        XCTAssertEqual(
+            MenuBarProviderPresentation(group: groups[0]).metrics,
+            []
         )
     }
 
     @MainActor
-    func testMultipleReadingStatusImageUsesTemplateRendering() {
-        let readings = [
-            MenuBarReading(
+    func testGroupedStatusImageUsesTemplateRendering() {
+        let groups = [
+            MenuBarProviderReadings(
                 provider: .claude,
-                percent: 62,
-                displayMode: .used,
-                isStale: false,
-                showsPlaceholder: false
+                selectedMetrics: [.sonnet],
+                readings: [
+                    MenuBarReading(
+                        provider: .claude,
+                        metric: .sonnet,
+                        value: .percentage(62),
+                        displayMode: .used,
+                        isStale: false
+                    )
+                ]
             ),
-            MenuBarReading(
+            MenuBarProviderReadings(
                 provider: .codex,
-                percent: 28,
-                displayMode: .used,
-                isStale: false,
-                showsPlaceholder: false
+                selectedMetrics: [.spark],
+                readings: [
+                    MenuBarReading(
+                        provider: .codex,
+                        metric: .spark,
+                        value: .percentage(28),
+                        displayMode: .used,
+                        isStale: false
+                    )
+                ]
             )
         ]
 
         let image = MenuBarStatusImageRenderer.image(
-            for: readings,
+            for: groups,
             font: NSFont.menuBarFont(ofSize: 0)
         )
 
         XCTAssertTrue(image.isTemplate)
-        XCTAssertGreaterThan(image.size.width, 50)
-        XCTAssertLessThan(image.size.width, 110)
+        XCTAssertGreaterThan(image.size.width, 55)
+        XCTAssertLessThan(image.size.width, 130)
+    }
+
+    @MainActor
+    func testMicroLabelsUseLessWidthThanFullSizePrefixes() {
+        let group = MenuBarProviderReadings(
+            provider: .claude,
+            selectedMetrics: [.session, .weekly],
+            readings: [
+                MenuBarReading(
+                    provider: .claude,
+                    metric: .session,
+                    value: .percentage(78),
+                    displayMode: .remaining,
+                    isStale: false
+                ),
+                MenuBarReading(
+                    provider: .claude,
+                    metric: .weekly,
+                    value: .percentage(42),
+                    displayMode: .remaining,
+                    isStale: false
+                )
+            ]
+        )
+        let font = NSFont.menuBarFont(ofSize: 0)
+        let image = MenuBarStatusImageRenderer.image(
+            for: [group],
+            font: font
+        )
+        let legacyValuesWidth = ["S 78%", "W 42%"]
+            .map {
+                ($0 as NSString).size(withAttributes: [.font: font]).width
+            }
+            .reduce(0, +) + 6
+        let legacyWidth = 15 + 3 + ceil(legacyValuesWidth)
+
+        XCTAssertLessThan(image.size.width, legacyWidth - 15)
     }
 }

--- a/AIUsageTests/MenuBarPresentationTests.swift
+++ b/AIUsageTests/MenuBarPresentationTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import XCTest
 @testable import AIUsage
 
@@ -43,5 +44,59 @@ final class MenuBarPresentationTests: XCTestCase {
 
         XCTAssertNil(presentation.valueText)
         XCTAssertEqual(presentation.accessibilityLabel, "AI usage")
+    }
+
+    func testMultipleReadingsKeepProviderValuesAndAccessibilityOrder() {
+        let presentation = MenuBarReadingsPresentation(readings: [
+            MenuBarReading(
+                provider: .claude,
+                percent: 62,
+                displayMode: .used,
+                isStale: false,
+                showsPlaceholder: false
+            ),
+            MenuBarReading(
+                provider: .codex,
+                percent: 28,
+                displayMode: .used,
+                isStale: true,
+                showsPlaceholder: false
+            )
+        ])
+
+        XCTAssertEqual(presentation.items.map(\.valueText), ["62%", "28%"])
+        XCTAssertEqual(
+            presentation.accessibilityLabel,
+            "Claude Code 62 percent used, Codex 28 percent used, stale"
+        )
+    }
+
+    @MainActor
+    func testMultipleReadingStatusImageUsesTemplateRendering() {
+        let readings = [
+            MenuBarReading(
+                provider: .claude,
+                percent: 62,
+                displayMode: .used,
+                isStale: false,
+                showsPlaceholder: false
+            ),
+            MenuBarReading(
+                provider: .codex,
+                percent: 28,
+                displayMode: .used,
+                isStale: false,
+                showsPlaceholder: false
+            )
+        ]
+
+        let image = MenuBarStatusImageRenderer.image(
+            for: readings,
+            font: NSFont.menuBarFont(ofSize: 0)
+        )
+
+        XCTAssertTrue(image.isTemplate)
+        XCTAssertGreaterThan(image.size.width, 50)
+        XCTAssertLessThan(image.size.width, 110)
     }
 }

--- a/AIUsageTests/TestDoubles.swift
+++ b/AIUsageTests/TestDoubles.swift
@@ -133,6 +133,29 @@ actor SequencedProvider: UsageProvider {
     }
 }
 
+actor CountingProvider: UsageProvider {
+    nonisolated let id: ProviderID
+    private let result: Result<ProviderSnapshot, ProviderFailure>
+    private var count = 0
+
+    init(
+        id: ProviderID,
+        result: Result<ProviderSnapshot, ProviderFailure>
+    ) {
+        self.id = id
+        self.result = result
+    }
+
+    func fetch() async throws -> ProviderSnapshot {
+        count += 1
+        return try result.get()
+    }
+
+    func fetchCallCount() -> Int {
+        count
+    }
+}
+
 func httpResponse(
     _ status: Int = 200,
     json: String = "{}",

--- a/AIUsageTests/UsageStoreTests.swift
+++ b/AIUsageTests/UsageStoreTests.swift
@@ -110,6 +110,67 @@ final class UsageStoreTests: XCTestCase {
         )
     }
 
+    func testAllSelectionReturnsEveryAvailableProviderInStableOrder() async {
+        let claude = SequencedProvider(
+            id: .claude,
+            results: [.success(snapshot(provider: .claude, percent: 20))]
+        )
+        let codex = SequencedProvider(
+            id: .codex,
+            results: [.success(snapshot(provider: .codex, percent: 81))]
+        )
+        let store = UsageStore(
+            providers: [claude, codex],
+            availabilityChecker: FixedProviderAvailabilityChecker()
+        )
+
+        await store.refresh()
+
+        XCTAssertEqual(
+            store.menuBarReadings(for: .all),
+            [
+                MenuBarReading(
+                    provider: .claude,
+                    percent: 20,
+                    displayMode: .used,
+                    isStale: false,
+                    showsPlaceholder: false
+                ),
+                MenuBarReading(
+                    provider: .codex,
+                    percent: 81,
+                    displayMode: .used,
+                    isStale: false,
+                    showsPlaceholder: false
+                )
+            ]
+        )
+    }
+
+    func testAllSelectionOmitsUnavailableProviders() async {
+        let claude = SequencedProvider(
+            id: .claude,
+            results: [.success(snapshot(provider: .claude, percent: 20))]
+        )
+        let codex = SequencedProvider(
+            id: .codex,
+            results: [.success(snapshot(provider: .codex, percent: 81))]
+        )
+        let store = UsageStore(
+            providers: [claude, codex],
+            availabilityChecker: FixedProviderAvailabilityChecker(
+                installed: [.claude]
+            )
+        )
+
+        await store.refresh()
+
+        XCTAssertEqual(
+            store.menuBarReadings(for: .all).map(\.provider),
+            [.claude]
+        )
+    }
+
     func testPinnedCodexFallsBackToAvailableWeeklyPeriod() async {
         let weeklyOnly = ProviderSnapshot(
             provider: .codex,

--- a/AIUsageTests/UsageStoreTests.swift
+++ b/AIUsageTests/UsageStoreTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @MainActor
 final class UsageStoreTests: XCTestCase {
-    func testTransientFailureRetainsLastGoodAndMarksItStale() async {
+    func testTransientFailureRetainsLastGoodAndMarksMetricStale() async {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let snapshot = ProviderSnapshot(
             provider: .claude,
@@ -20,8 +20,11 @@ final class UsageStoreTests: XCTestCase {
         )
         let store = UsageStore(
             providers: [claude],
-            availabilityChecker: FixedProviderAvailabilityChecker()
+            availabilityChecker: FixedProviderAvailabilityChecker(
+                installed: [.claude]
+            )
         )
+        let item = MenuBarItemID(provider: .claude, metric: .session)
 
         await store.refresh()
         await store.refresh()
@@ -29,18 +32,18 @@ final class UsageStoreTests: XCTestCase {
         XCTAssertEqual(store.states[.claude]?.snapshot, snapshot)
         XCTAssertTrue(store.states[.claude]?.isStale == true)
         XCTAssertEqual(
-            store.menuBarReading(for: .automatic),
+            store.menuBarReading(for: item),
             MenuBarReading(
                 provider: .claude,
-                percent: 72,
+                metric: .session,
+                value: .percentage(72),
                 displayMode: .used,
-                isStale: true,
-                showsPlaceholder: false
+                isStale: true
             )
         )
     }
 
-    func testAuthenticationFailureClearsLastGood() async {
+    func testAuthenticationFailureClearsLastGoodAndHidesUnavailableMetric() async {
         let snapshot = ProviderSnapshot(
             provider: .codex,
             planName: nil,
@@ -56,105 +59,181 @@ final class UsageStoreTests: XCTestCase {
         )
         let store = UsageStore(
             providers: [codex],
-            availabilityChecker: FixedProviderAvailabilityChecker()
+            availabilityChecker: FixedProviderAvailabilityChecker(
+                installed: [.codex]
+            )
         )
+        let item = MenuBarItemID(provider: .codex, metric: .session)
 
         await store.refresh()
         await store.refresh()
 
         XCTAssertNil(store.states[.codex]?.snapshot)
-        XCTAssertEqual(
-            store.menuBarReading(for: .codex),
-            MenuBarReading(
-                provider: .codex,
-                percent: nil,
-                displayMode: .used,
-                isStale: false,
-                showsPlaceholder: true
-            )
-        )
+        XCTAssertNil(store.menuBarReading(for: item))
+        XCTAssertEqual(store.availableMenuBarItems(for: .codex), [])
     }
 
-    func testAutomaticIndicatorChoosesHighestAvailableSession() async {
+    func testMenuBarReadingsUseExactMetricsInUserOrder() async {
         let claude = SequencedProvider(
             id: .claude,
-            results: [.success(snapshot(provider: .claude, percent: 20))]
+            results: [.success(snapshot(
+                provider: .claude,
+                session: 20,
+                weekly: 35
+            ))]
         )
         let codex = SequencedProvider(
             id: .codex,
-            results: [.success(snapshot(provider: .codex, percent: 81))]
+            results: [.success(snapshot(
+                provider: .codex,
+                session: 81,
+                weekly: 42
+            ))]
         )
         let store = UsageStore(
             providers: [claude, codex],
             availabilityChecker: FixedProviderAvailabilityChecker()
         )
+        let items = [
+            MenuBarItemID(provider: .codex, metric: .weekly),
+            MenuBarItemID(provider: .claude, metric: .session),
+            MenuBarItemID(provider: .claude, metric: .weekly)
+        ]
 
         await store.refresh()
 
-        XCTAssertEqual(store.menuBarReading(for: .automatic).percent, 81)
-        XCTAssertEqual(store.menuBarReading(for: .automatic).provider, .codex)
-        XCTAssertEqual(store.menuBarReading(for: .claude).percent, 20)
+        let readings = store.menuBarReadings(for: items)
+        XCTAssertEqual(readings.map(\.provider), [.codex, .claude, .claude])
+        XCTAssertEqual(readings.map(\.metric), [.weekly, .session, .weekly])
         XCTAssertEqual(
-            store.menuBarReading(
-                for: .automatic,
-                window: .session,
-                displayMode: .remaining
-            ),
-            MenuBarReading(
-                provider: .codex,
-                percent: 19,
-                displayMode: .remaining,
-                isStale: false,
-                showsPlaceholder: false
-            )
-        )
-    }
-
-    func testAllSelectionReturnsEveryAvailableProviderInStableOrder() async {
-        let claude = SequencedProvider(
-            id: .claude,
-            results: [.success(snapshot(provider: .claude, percent: 20))]
-        )
-        let codex = SequencedProvider(
-            id: .codex,
-            results: [.success(snapshot(provider: .codex, percent: 81))]
-        )
-        let store = UsageStore(
-            providers: [claude, codex],
-            availabilityChecker: FixedProviderAvailabilityChecker()
+            readings.map(\.value),
+            [.percentage(42), .percentage(20), .percentage(35)]
         )
 
-        await store.refresh()
-
-        XCTAssertEqual(
-            store.menuBarReadings(for: .all),
-            [
-                MenuBarReading(
-                    provider: .claude,
-                    percent: 20,
-                    displayMode: .used,
-                    isStale: false,
-                    showsPlaceholder: false
-                ),
-                MenuBarReading(
+        let groups = store.menuBarProviderReadings(
+            for: [
+                MenuBarProviderConfiguration(
                     provider: .codex,
-                    percent: 81,
-                    displayMode: .used,
-                    isStale: false,
-                    showsPlaceholder: false
+                    metrics: [.weekly]
+                ),
+                MenuBarProviderConfiguration(
+                    provider: .claude,
+                    metrics: [.session, .weekly]
                 )
             ]
         )
+        XCTAssertEqual(groups.map(\.provider), [.codex, .claude])
+        XCTAssertEqual(groups[0].readings.map(\.metric), [.weekly])
+        XCTAssertEqual(
+            groups[1].readings.map(\.metric),
+            [.session, .weekly]
+        )
     }
 
-    func testAllSelectionOmitsUnavailableProviders() async {
-        let claude = SequencedProvider(
-            id: .claude,
-            results: [.success(snapshot(provider: .claude, percent: 20))]
-        )
+    func testExplicitWeeklyMetricNeverFallsBackToSession() async {
         let codex = SequencedProvider(
             id: .codex,
-            results: [.success(snapshot(provider: .codex, percent: 81))]
+            results: [.success(ProviderSnapshot(
+                provider: .codex,
+                planName: "Pro",
+                windows: [
+                    QuotaWindow(
+                        kind: .session,
+                        usedPercent: 17,
+                        resetsAt: nil
+                    )
+                ],
+                fetchedAt: Date()
+            ))]
+        )
+        let store = UsageStore(
+            providers: [codex],
+            availabilityChecker: FixedProviderAvailabilityChecker(
+                installed: [.codex]
+            )
+        )
+        let weekly = MenuBarItemID(provider: .codex, metric: .weekly)
+
+        await store.refresh()
+
+        XCTAssertNil(store.menuBarReading(for: weekly))
+        XCTAssertFalse(store.isMenuBarItemAvailable(weekly))
+    }
+
+    func testAvailableMetricsComeOnlyFromTheLiveSnapshot() async {
+        let snapshot = ProviderSnapshot(
+            provider: .codex,
+            planName: "Pro",
+            windows: [
+                QuotaWindow(
+                    kind: .weekly,
+                    usedPercent: 37,
+                    resetsAt: nil
+                ),
+                QuotaWindow(
+                    kind: .sparkSession,
+                    usedPercent: 14,
+                    resetsAt: nil
+                ),
+                QuotaWindow(
+                    kind: .sparkWeekly,
+                    usedPercent: 48,
+                    resetsAt: nil
+                )
+            ],
+            billingUsage: .flexCreditBalance(
+                remainingCredits: 120,
+                usdValue: 4.8
+            ),
+            fetchedAt: Date()
+        )
+        let store = UsageStore(
+            providers: [
+                SequencedProvider(id: .codex, results: [.success(snapshot)])
+            ],
+            availabilityChecker: FixedProviderAvailabilityChecker(
+                installed: [.codex]
+            )
+        )
+
+        await store.refresh()
+
+        XCTAssertEqual(
+            store.availableMenuBarItems(for: .codex),
+            [
+                MenuBarItemID(provider: .codex, metric: .weekly),
+                MenuBarItemID(provider: .codex, metric: .spark),
+                MenuBarItemID(provider: .codex, metric: .sparkWeekly),
+                MenuBarItemID(provider: .codex, metric: .credits)
+            ]
+        )
+        XCTAssertFalse(store.isMenuBarItemAvailable(
+            MenuBarItemID(provider: .codex, metric: .session)
+        ))
+        XCTAssertEqual(
+            store.menuBarReading(
+                for: MenuBarItemID(provider: .codex, metric: .credits)
+            )?.value,
+            .credits(remaining: 120, usdValue: 4.8)
+        )
+    }
+
+    func testMissingToolIsNeitherFetchedNorShown() async {
+        let claude = CountingProvider(
+            id: .claude,
+            result: .success(snapshot(
+                provider: .claude,
+                session: 20,
+                weekly: 35
+            ))
+        )
+        let codex = CountingProvider(
+            id: .codex,
+            result: .success(snapshot(
+                provider: .codex,
+                session: 81,
+                weekly: 42
+            ))
         )
         let store = UsageStore(
             providers: [claude, codex],
@@ -164,187 +243,224 @@ final class UsageStoreTests: XCTestCase {
         )
 
         await store.refresh()
+        let claudeFetches = await claude.fetchCallCount()
+        let codexFetches = await codex.fetchCallCount()
 
+        XCTAssertEqual(claudeFetches, 1)
+        XCTAssertEqual(codexFetches, 0)
+        XCTAssertTrue(store.isProviderVisibleInDashboard(.claude))
+        XCTAssertFalse(store.isProviderVisibleInDashboard(.codex))
         XCTAssertEqual(
-            store.menuBarReadings(for: .all).map(\.provider),
+            store.menuBarReadings(for: [
+                MenuBarItemID(provider: .claude, metric: .session),
+                MenuBarItemID(provider: .codex, metric: .session)
+            ]).map(\.provider),
+            [.claude]
+        )
+        XCTAssertEqual(
+            store.menuBarProviderReadings(
+                for: [
+                    MenuBarProviderConfiguration(
+                        provider: .claude,
+                        metrics: [.session]
+                    ),
+                    MenuBarProviderConfiguration(
+                        provider: .codex,
+                        metrics: [.session]
+                    )
+                ]
+            ).map(\.provider),
             [.claude]
         )
     }
 
-    func testPinnedCodexFallsBackToAvailableWeeklyPeriod() async {
-        let weeklyOnly = ProviderSnapshot(
-            provider: .codex,
-            planName: "Pro",
-            windows: [
-                QuotaWindow(kind: .weekly, usedPercent: 43, resetsAt: nil),
-                QuotaWindow(kind: .sparkWeekly, usedPercent: 12, resetsAt: nil)
-            ],
-            fetchedAt: Date()
-        )
-        let store = UsageStore(
-            providers: [
-                SequencedProvider(
-                    id: .codex,
-                    results: [.success(weeklyOnly)]
+    func testWeeklyDefaultsRenderOnlyInstalledProviders() async {
+        let installCombinations: [Set<ProviderID>] = [
+            [],
+            [.claude],
+            [.codex],
+            [.claude, .codex]
+        ]
+
+        for installedProviders in installCombinations {
+            let claude = CountingProvider(
+                id: .claude,
+                result: .success(snapshot(
+                    provider: .claude,
+                    session: 20,
+                    weekly: 35
+                ))
+            )
+            let codex = CountingProvider(
+                id: .codex,
+                result: .success(snapshot(
+                    provider: .codex,
+                    session: 81,
+                    weekly: 42
+                ))
+            )
+            let store = UsageStore(
+                providers: [claude, codex],
+                availabilityChecker: FixedProviderAvailabilityChecker(
+                    installed: installedProviders
                 )
-            ],
-            availabilityChecker: FixedProviderAvailabilityChecker()
-        )
-
-        await store.refresh()
-
-        XCTAssertEqual(
-            store.menuBarReading(for: .codex),
-            MenuBarReading(
-                provider: .codex,
-                percent: 43,
-                displayMode: .used,
-                isStale: false,
-                showsPlaceholder: false
             )
-        )
-        XCTAssertEqual(
-            store.menuBarReading(for: .codex, window: .weekly),
-            MenuBarReading(
-                provider: .codex,
-                percent: 43,
-                displayMode: .used,
-                isStale: false,
-                showsPlaceholder: false
+
+            await store.refresh()
+
+            let suiteName =
+                "UsageStoreTests.installation.\(UUID().uuidString)"
+            let defaults = UserDefaults(suiteName: suiteName)!
+            defaults.removePersistentDomain(forName: suiteName)
+            let preferences = AppPreferences(defaults: defaults)
+            preferences.configureDefaultMenuBarProviders(
+                availableItemsByProvider:
+                    store.availableMenuBarItemsByProvider
             )
-        )
+
+            XCTAssertEqual(
+                preferences.selectedMenuBarMetrics(for: .claude),
+                [.weekly]
+            )
+            XCTAssertEqual(
+                preferences.selectedMenuBarMetrics(for: .codex),
+                [.weekly]
+            )
+            XCTAssertEqual(
+                store.menuBarProviderReadings(
+                    for: preferences.menuBarProviderConfigurations
+                ).map(\.provider),
+                ProviderID.allCases.filter(installedProviders.contains)
+            )
+            for provider in ProviderID.allCases {
+                XCTAssertEqual(
+                    store.isProviderVisibleInDashboard(provider),
+                    installedProviders.contains(provider)
+                )
+            }
+            let claudeFetches = await claude.fetchCallCount()
+            let codexFetches = await codex.fetchCallCount()
+            XCTAssertEqual(
+                claudeFetches,
+                installedProviders.contains(.claude) ? 1 : 0
+            )
+            XCTAssertEqual(
+                codexFetches,
+                installedProviders.contains(.codex) ? 1 : 0
+            )
+
+            defaults.removePersistentDomain(forName: suiteName)
+        }
     }
 
-    func testPinnedProviderPrefersTheExactSelectedPeriod() async {
-        let store = UsageStore(
-            providers: [
-                SequencedProvider(
-                    id: .codex,
-                    results: [.success(ProviderSnapshot(
-                        provider: .codex,
-                        planName: "Pro",
-                        windows: [
-                            QuotaWindow(
-                                kind: .session,
-                                usedPercent: 17,
-                                resetsAt: nil
-                            ),
-                            QuotaWindow(
-                                kind: .weekly,
-                                usedPercent: 43,
-                                resetsAt: nil
-                            )
-                        ],
-                        fetchedAt: Date()
-                    ))]
-                )
-            ],
-            availabilityChecker: FixedProviderAvailabilityChecker()
-        )
-
-        await store.refresh()
-
-        XCTAssertEqual(store.menuBarReading(for: .codex).percent, 17)
-        XCTAssertEqual(
-            store.menuBarReading(for: .codex, window: .weekly).percent,
-            43
-        )
-    }
-
-    func testPinnedProviderFallsBackFromWeeklyToSession() async {
-        let store = UsageStore(
-            providers: [
-                SequencedProvider(
-                    id: .codex,
-                    results: [.success(snapshot(provider: .codex, percent: 17))]
-                )
-            ],
-            availabilityChecker: FixedProviderAvailabilityChecker()
-        )
-
-        await store.refresh()
-
-        XCTAssertEqual(
-            store.menuBarReading(for: .codex, window: .weekly),
-            MenuBarReading(
-                provider: .codex,
-                percent: 17,
-                displayMode: .used,
-                isStale: false,
-                showsPlaceholder: false
-            )
-        )
-    }
-
-    func testPinnedProviderShowsPlaceholderWithoutPrimaryWindows() async {
-        let store = UsageStore(
-            providers: [
-                SequencedProvider(
-                    id: .codex,
-                    results: [.success(ProviderSnapshot(
-                        provider: .codex,
-                        planName: "Pro",
-                        windows: [
-                            QuotaWindow(
-                                kind: .sparkWeekly,
-                                usedPercent: 12,
-                                resetsAt: nil
-                            )
-                        ],
-                        fetchedAt: Date()
-                    ))]
-                )
-            ],
-            availabilityChecker: FixedProviderAvailabilityChecker()
-        )
-
-        await store.refresh()
-
-        XCTAssertEqual(
-            store.menuBarReading(for: .codex),
-            MenuBarReading(
-                provider: .codex,
-                percent: nil,
-                displayMode: .used,
-                isStale: false,
-                showsPlaceholder: true
-            )
-        )
-    }
-
-    func testAutomaticIndicatorDoesNotFallbackAcrossPeriods() async {
-        let claude = SequencedProvider(
+    func testUntrackedProviderIsNeitherFetchedNorShown() async {
+        let claude = CountingProvider(
             id: .claude,
-            results: [.success(snapshot(provider: .claude, percent: 20))]
+            result: .success(snapshot(
+                provider: .claude,
+                session: 20,
+                weekly: 35
+            ))
         )
-        let weeklyCodex = ProviderSnapshot(
-            provider: .codex,
-            planName: "Pro",
-            windows: [
-                QuotaWindow(kind: .weekly, usedPercent: 81, resetsAt: nil)
-            ],
-            fetchedAt: Date()
-        )
-        let codex = SequencedProvider(
+        let codex = CountingProvider(
             id: .codex,
-            results: [.success(weeklyCodex)]
+            result: .success(snapshot(
+                provider: .codex,
+                session: 81,
+                weekly: 42
+            ))
         )
         let store = UsageStore(
             providers: [claude, codex],
-            availabilityChecker: FixedProviderAvailabilityChecker()
+            availabilityChecker: FixedProviderAvailabilityChecker(),
+            trackedProviderIDs: [.claude]
+        )
+
+        await store.refresh()
+        let claudeFetches = await claude.fetchCallCount()
+        let codexFetches = await codex.fetchCallCount()
+
+        XCTAssertEqual(claudeFetches, 1)
+        XCTAssertEqual(codexFetches, 0)
+        XCTAssertTrue(store.isProviderVisibleInDashboard(.claude))
+        XCTAssertFalse(store.isProviderVisibleInDashboard(.codex))
+    }
+
+    func testEnablingTrackingRefreshesOnlyTheNewProvider() async {
+        let claude = CountingProvider(
+            id: .claude,
+            result: .success(snapshot(
+                provider: .claude,
+                session: 20,
+                weekly: 35
+            ))
+        )
+        let codex = CountingProvider(
+            id: .codex,
+            result: .success(snapshot(
+                provider: .codex,
+                session: 81,
+                weekly: 42
+            ))
+        )
+        let store = UsageStore(
+            providers: [claude, codex],
+            availabilityChecker: FixedProviderAvailabilityChecker(),
+            trackedProviderIDs: [.claude]
+        )
+        store.start()
+        await store.refresh()
+
+        store.setTrackedProviders([.claude, .codex])
+        await Task.yield()
+        await store.refresh(providerIDs: [.codex])
+
+        let claudeFetches = await claude.fetchCallCount()
+        let codexFetches = await codex.fetchCallCount()
+        XCTAssertEqual(claudeFetches, 1)
+        XCTAssertEqual(codexFetches, 1)
+        store.stop()
+    }
+
+    func testInstalledButLoggedOutProviderRemainsVisible() async {
+        let store = UsageStore(
+            providers: [
+                SequencedProvider(
+                    id: .claude,
+                    results: [.failure(ProviderFailure(
+                        .authentication,
+                        "Not logged in. Run `claude` to authenticate."
+                    ))]
+                )
+            ],
+            availabilityChecker: FixedProviderAvailabilityChecker(
+                installed: [.claude]
+            )
         )
 
         await store.refresh()
 
+        XCTAssertTrue(store.isProviderVisibleInDashboard(.claude))
         XCTAssertEqual(
-            store.menuBarReading(for: .automatic, window: .session),
-            MenuBarReading(
-                provider: .claude,
-                percent: 20,
-                displayMode: .used,
-                isStale: false,
-                showsPlaceholder: false
-            )
+            store.states[.claude]?.failure?.kind,
+            .authentication
+        )
+        XCTAssertEqual(
+            store.menuBarProviderReadings(
+                for: [
+                    MenuBarProviderConfiguration(
+                        provider: .claude,
+                        metrics: [.session]
+                    )
+                ]
+            ),
+            [
+                MenuBarProviderReadings(
+                    provider: .claude,
+                    selectedMetrics: [.session],
+                    readings: []
+                )
+            ]
         )
     }
 
@@ -381,44 +497,26 @@ final class UsageStoreTests: XCTestCase {
         XCTAssertEqual(UsageDisplayMode.allCases, [.remaining, .used])
     }
 
-    func testToolAvailabilityIsIndependentFromLoginStatus() async {
-        let store = UsageStore(
-            providers: [
-                SequencedProvider(
-                    id: .claude,
-                    results: [.failure(ProviderFailure(
-                        .authentication,
-                        "Not logged in. Run `claude` to authenticate."
-                    ))]
-                ),
-                SequencedProvider(
-                    id: .codex,
-                    results: [.failure(ProviderFailure(
-                        .authentication,
-                        "Not logged in. Run `codex` to authenticate."
-                    ))]
-                )
-            ],
-            availabilityChecker: FixedProviderAvailabilityChecker(
-                installed: [.claude]
-            )
-        )
-
-        await store.refresh()
-
-        XCTAssertTrue(store.states[.claude]?.isVisibleInDashboard == true)
-        XCTAssertEqual(
-            store.states[.claude]?.failure?.message,
-            "Not logged in. Run `claude` to authenticate."
-        )
-        XCTAssertTrue(store.states[.codex]?.isVisibleInDashboard == false)
-    }
-
-    private func snapshot(provider: ProviderID, percent: Double) -> ProviderSnapshot {
+    private func snapshot(
+        provider: ProviderID,
+        session: Double,
+        weekly: Double
+    ) -> ProviderSnapshot {
         ProviderSnapshot(
             provider: provider,
             planName: nil,
-            windows: [QuotaWindow(kind: .session, usedPercent: percent, resetsAt: nil)],
+            windows: [
+                QuotaWindow(
+                    kind: .session,
+                    usedPercent: session,
+                    resetsAt: nil
+                ),
+                QuotaWindow(
+                    kind: .weekly,
+                    usedPercent: weekly,
+                    resetsAt: nil
+                )
+            ],
             fetchedAt: Date()
         )
     }

--- a/AIUsageTests/VisualSnapshotTests.swift
+++ b/AIUsageTests/VisualSnapshotTests.swift
@@ -68,17 +68,25 @@ final class VisualSnapshotTests: XCTestCase {
     func testMenuBarLabelKeepsUsageMeaningOutOfVisibleText() {
         for displayMode in UsageDisplayMode.allCases {
             let size = measuredSize(
-                of: MenuBarLabelView(reading: MenuBarReading(
-                    provider: .codex,
-                    percent: 62,
-                    displayMode: displayMode,
-                    isStale: false,
-                    showsPlaceholder: false
-                )),
+                of: MenuBarProviderLabelView(
+                    group: MenuBarProviderReadings(
+                        provider: .codex,
+                        selectedMetrics: [.weekly],
+                        readings: [
+                            MenuBarReading(
+                                provider: .codex,
+                                metric: .weekly,
+                                value: .percentage(62),
+                                displayMode: displayMode,
+                                isStale: false
+                            )
+                        ]
+                    )
+                ),
                 width: 200
             )
 
-            XCTAssertLessThan(size.width, 60)
+            XCTAssertLessThan(size.width, 75)
         }
     }
 
@@ -94,8 +102,6 @@ final class VisualSnapshotTests: XCTestCase {
             let view = DashboardView(
                 store: store,
                 launchAtLogin: LaunchAtLoginController(service: SnapshotLoginService()),
-                menuBarSelection: .constant(.automatic),
-                menuBarWindow: .constant(.session),
                 usageDisplayMode: .constant(.used),
                 refreshInterval: .constant(.fiveMinutes),
                 availableUpdateVersion: nil,
@@ -116,8 +122,6 @@ final class VisualSnapshotTests: XCTestCase {
         let view = DashboardView(
             store: store,
             launchAtLogin: LaunchAtLoginController(service: SnapshotLoginService()),
-            menuBarSelection: .constant(.codex),
-            menuBarWindow: .constant(.weekly),
             usageDisplayMode: .constant(.remaining),
             refreshInterval: .constant(.fifteenMinutes),
             availableUpdateVersion: "0.2.0",
@@ -130,6 +134,37 @@ final class VisualSnapshotTests: XCTestCase {
         XCTAssertEqual(size.width, panelWidth, accuracy: 0.5)
         XCTAssertLessThan(size.height, 500)
         XCTAssertGreaterThan(size.height, 250)
+    }
+
+    func testSettingsFitsTheMenuBarPopoverInLightAndDark() async {
+        let store = await makePopulatedStore()
+        let suiteName = "VisualSnapshotTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        let preferences = AppPreferences(defaults: defaults)
+        preferences.configureDefaultMenuBarProviders(
+            availableItemsByProvider: store.availableMenuBarItemsByProvider
+        )
+
+        for colorScheme in [ColorScheme.light, .dark] {
+            let view = SettingsView(
+                store: store,
+                preferences: preferences,
+                launchAtLogin: LaunchAtLoginController(
+                    service: SnapshotLoginService()
+                ),
+                updateController: UpdateController(startingUpdater: false)
+            )
+            .environment(\.colorScheme, colorScheme)
+
+            let width = MenuBarPanelRoute.settings.width
+            let size = measuredSize(of: view, width: width)
+            XCTAssertEqual(size.width, width, accuracy: 0.5)
+            XCTAssertLessThan(size.height, 500)
+            XCTAssertGreaterThan(size.height, 300)
+        }
+
+        defaults.removePersistentDomain(forName: suiteName)
     }
 
     func testProviderSurfaceKeepsOddQuotaCountCompact() {
@@ -151,54 +186,47 @@ final class VisualSnapshotTests: XCTestCase {
         XCTAssertGreaterThan(size.height, 130)
     }
 
-    func testCreditUsageAddsOneCompactProviderRow() {
-        let windows = [
-            QuotaWindow(
-                kind: .session,
-                usedPercent: 28,
-                resetsAt: Date().addingTimeInterval(3_600)
+    func testBillingUsagePresentationKeepsProviderSemanticsDistinct() {
+        let locale = Locale(identifier: "en_US")
+        let bounded = BillingUsage.boundedSpend(
+            usedAmount: 5,
+            limitAmount: 10,
+            currencyCode: "USD"
+        )
+        let used = BillingUsagePresentation(
+            usage: bounded,
+            displayMode: .used,
+            locale: locale
+        )
+        let remaining = BillingUsagePresentation(
+            usage: bounded,
+            displayMode: .remaining,
+            locale: locale
+        )
+        let uncapped = BillingUsagePresentation(
+            usage: .unboundedSpend(
+                usedAmount: 1234.56,
+                currencyCode: "USD"
             ),
-            QuotaWindow(
-                kind: .weekly,
-                usedPercent: 52,
-                resetsAt: Date().addingTimeInterval(86_400)
-            )
-        ]
-        let withoutCredits = ProviderState(
-            provider: .claude,
-            snapshot: ProviderSnapshot(
-                provider: .claude,
-                planName: "Pro",
-                windows: windows,
-                fetchedAt: Date()
-            )
+            displayMode: .remaining,
+            locale: locale
         )
-        let withCredits = ProviderState(
-            provider: .claude,
-            snapshot: ProviderSnapshot(
-                provider: .claude,
-                planName: "Pro",
-                windows: windows,
-                creditUsage: CreditUsage(
-                    usedAmount: 99.99,
-                    limitAmount: 200,
-                    usedPercent: 49.995
-                ),
-                fetchedAt: Date()
-            )
+        let credits = BillingUsagePresentation(
+            usage: .flexCreditBalance(
+                remainingCredits: 820,
+                usdValue: 32.8
+            ),
+            displayMode: .used,
+            locale: locale
         )
 
-        let baseSize = measuredSize(
-            of: ProviderSectionView(state: withoutCredits),
-            width: panelWidth - 20
-        )
-        let creditSize = measuredSize(
-            of: ProviderSectionView(state: withCredits),
-            width: panelWidth - 20
-        )
-
-        XCTAssertGreaterThan(creditSize.height, baseSize.height + 20)
-        XCTAssertLessThan(creditSize.height, baseSize.height + 40)
+        XCTAssertEqual(used.title, "Extra usage")
+        XCTAssertEqual(used.valueText, "$5.00 / $10.00 spent")
+        XCTAssertEqual(remaining.valueText, "$5.00 / $10.00 left")
+        XCTAssertEqual(uncapped.valueText, "$1,234.56 spent")
+        XCTAssertEqual(credits.title, "Credits")
+        XCTAssertEqual(credits.valueText, "$32.80 · 820 credits left")
+        XCTAssertTrue(credits.accessibilityValue.contains("remaining"))
     }
 
     func testProviderLoadingAndTransientFailureStatesStayInsideOneCompactSurface() {
@@ -269,6 +297,11 @@ final class VisualSnapshotTests: XCTestCase {
                         resetsAt: now.addingTimeInterval(345_600)
                     )
                 ],
+                billingUsage: .boundedSpend(
+                    usedAmount: 5,
+                    limitAmount: 10,
+                    currencyCode: "USD"
+                ),
                 fetchedAt: now
             ))]
         )
@@ -299,6 +332,10 @@ final class VisualSnapshotTests: XCTestCase {
                         resetsAt: now.addingTimeInterval(432_000)
                     )
                 ],
+                billingUsage: .flexCreditBalance(
+                    remainingCredits: 820,
+                    usdValue: 32.8
+                ),
                 fetchedAt: now
             ))]
         )

--- a/AIUsageTests/VisualSnapshotTests.swift
+++ b/AIUsageTests/VisualSnapshotTests.swift
@@ -151,6 +151,56 @@ final class VisualSnapshotTests: XCTestCase {
         XCTAssertGreaterThan(size.height, 130)
     }
 
+    func testCreditUsageAddsOneCompactProviderRow() {
+        let windows = [
+            QuotaWindow(
+                kind: .session,
+                usedPercent: 28,
+                resetsAt: Date().addingTimeInterval(3_600)
+            ),
+            QuotaWindow(
+                kind: .weekly,
+                usedPercent: 52,
+                resetsAt: Date().addingTimeInterval(86_400)
+            )
+        ]
+        let withoutCredits = ProviderState(
+            provider: .claude,
+            snapshot: ProviderSnapshot(
+                provider: .claude,
+                planName: "Pro",
+                windows: windows,
+                fetchedAt: Date()
+            )
+        )
+        let withCredits = ProviderState(
+            provider: .claude,
+            snapshot: ProviderSnapshot(
+                provider: .claude,
+                planName: "Pro",
+                windows: windows,
+                creditUsage: CreditUsage(
+                    usedAmount: 99.99,
+                    limitAmount: 200,
+                    usedPercent: 49.995
+                ),
+                fetchedAt: Date()
+            )
+        )
+
+        let baseSize = measuredSize(
+            of: ProviderSectionView(state: withoutCredits),
+            width: panelWidth - 20
+        )
+        let creditSize = measuredSize(
+            of: ProviderSectionView(state: withCredits),
+            width: panelWidth - 20
+        )
+
+        XCTAssertGreaterThan(creditSize.height, baseSize.height + 20)
+        XCTAssertLessThan(creditSize.height, baseSize.height + 40)
+    }
+
     func testProviderLoadingAndTransientFailureStatesStayInsideOneCompactSurface() {
         var loadingState = ProviderState(provider: .claude)
         loadingState.isRefreshing = true


### PR DESCRIPTION
## Summary

- show Claude Code and Codex together with compact, exact live metrics
- map Claude extra usage and Codex credit balances using provider-native semantics
- add a native menu-bar settings popover for tracking, visibility, and per-provider metric choices
- default fresh installs and legacy upgrades to Weekly for both providers exactly once
- preserve every user choice on later updates, including skipped-version upgrades
- hide tools that are not installed while keeping installed-but-logged-out providers visible
- keep the menu-bar app idle-efficient with refresh work only on its selected cadence

## Validation

- `xcodebuild test -project AIUsage.xcodeproj -scheme AIUsage -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`
- Release arm64 build
- Release static analysis
- dark-mode runtime QA for dashboard/settings popover transitions
- light/dark layout coverage in visual tests
